### PR TITLE
Partial Fix to #490 + Furthur Improvements for #515

### DIFF
--- a/app/models/evaluation_mixeval.php
+++ b/app/models/evaluation_mixeval.php
@@ -411,22 +411,15 @@ class EvaluationMixeval extends EvaluationResponseBase
 
         $data = array();
         
-        //chunk find
-        $total = $this->find('count', array('conditions' => $conditions));
-        $limit = 500;
-        $pages = ceil($total / $limit);
-        for ($page = 1; $page < $pages + 1; $page++) {
-            $list = $this->find('all', array('fields' => $fields, 'conditions' => $conditions, 'limit' => $limit, 'page' => $page));
-            
-            foreach($list as &$mark) {
-                if (!isset($data[$mark['EvaluationMixeval']['evaluatee']])) {
-                    $data[$mark['EvaluationMixeval']['evaluatee']]['user_id'] = $mark['EvaluationMixeval']['evaluatee'];
-                    $data[$mark['EvaluationMixeval']['evaluatee']]['score'] = $mark['EvaluationMixeval']['score'];
-                    $data[$mark['EvaluationMixeval']['evaluatee']]['numEval']= 1;
-                } else {
-                    $data[$mark['EvaluationMixeval']['evaluatee']]['score'] += $mark['EvaluationMixeval']['score'];
-                    $data[$mark['EvaluationMixeval']['evaluatee']]['numEval']++;
-                }
+        $list = $this->find('all', array('fields' => $fields, 'conditions' => $conditions, 'contain' => false));
+        foreach($list as $mark) {
+            if (!isset($data[$mark['EvaluationMixeval']['evaluatee']])) {
+                $data[$mark['EvaluationMixeval']['evaluatee']]['user_id'] = $mark['EvaluationMixeval']['evaluatee'];
+                $data[$mark['EvaluationMixeval']['evaluatee']]['score'] = $mark['EvaluationMixeval']['score'];
+                $data[$mark['EvaluationMixeval']['evaluatee']]['numEval']= 1;
+            } else {
+                $data[$mark['EvaluationMixeval']['evaluatee']]['score'] += $mark['EvaluationMixeval']['score'];
+                $data[$mark['EvaluationMixeval']['evaluatee']]['numEval']++;
             }
         }
         //cleanup
@@ -436,7 +429,7 @@ class EvaluationMixeval extends EvaluationResponseBase
         $event = $this->Event->find('first', array('conditions' => array('Event.id' => $eventId)));
         $penalties = $pen->getPenaltyByEventId($eventId);
 
-        foreach ($sub as &$stu) {
+        foreach ($sub as $stu) {
             if (isset($data[$stu['EvaluationSubmission']['submitter_id']])) {
                 $diff = strtotime($stu['EvaluationSubmission']['date_submitted']) - strtotime($event['Event']['due_date']);
                 $days = $diff/(60*60*24);
@@ -449,14 +442,14 @@ class EvaluationMixeval extends EvaluationResponseBase
         //cleanup
         unset($sub);
 
-        foreach ($data as &$demo) {
+        foreach ($data as $demo) {
             if (!isset($demo['penalty'])) {
                 $data[$demo['user_id']]['penalty'] = 0;
             }
         }
 
         $grades = array();
-        foreach ($data as &$student) {
+        foreach ($data as $student) {
             $tmp = array();
             $tmp['id'] = 0;
             $tmp['evaluatee'] = $student['user_id'];

--- a/app/models/evaluation_rubric.php
+++ b/app/models/evaluation_rubric.php
@@ -396,14 +396,19 @@ class EvaluationRubric extends EvaluationResponseBase
         
         
         $rubricDetails = array();
-        
+        /*
+         * Note: The reason for using paging for results even though we are retrieving everthing is because in cakephp 1.3 associated are fetched 
+         * using the list of result ids in a where id in (list of ids). This is very bad for MySQL performance with very large lists which can happen
+         * in larger classes. 100 items seems to be a good balance based on development enviroment testing.$_COOKIE
+         * See cake/libs/model/datasources/dbo_source.php functions queryAssociation and fetchAssociated 
+        */
         //chunk find
-        $total = $this->find('count', array('conditions' => array_merge(array('evaluator' => $submitted), $conditions) ));
-        $limit = 500;
+        $total = $this->find('count', array('conditions' => array_merge(array('evaluator' => $submitted), $conditions), 'contain' => 'EvaluationRubricDetail' ));
+        $limit = 100;
         $pages = ceil($total / $limit);
         for ($page = 1; $page < $pages + 1; $page++) {
-            $list = $this->find('all', array('conditions' => array_merge(array('evaluator' => $submitted), $conditions), 'limit' => $limit, 'page' => $page));
-            
+            $list = $this->find('all', array('conditions' => array_merge(array('evaluator' => $submitted), $conditions), 'limit' => $limit, 'page' => $page, 'contain' => 'EvaluationRubricDetail'));
+        
             $rubricDetails = array_merge_recursive($rubricDetails, $list);
         }
         //cleanup
@@ -419,7 +424,7 @@ class EvaluationRubric extends EvaluationResponseBase
         $penalties = $pen->getPenaltyForMembers(array_keys($scoreRecords), $event['Event'], $sub);
 
         $grades = array();
-        foreach ($scoreRecords as $user_id => &$record) {
+        foreach ($scoreRecords as $user_id => $record) {
             $grades[] = array(
                 'EvaluationRubric' => array(
                     'id' => 0,

--- a/app/models/evaluation_simple.php
+++ b/app/models/evaluation_simple.php
@@ -511,22 +511,15 @@ class EvaluationSimple extends EvaluationResponseBase
 
         $data = array();
         
-        //chunk find
-        $total = $this->find('count', array('conditions' => $conditions));
-        $limit = 500;
-        $pages = ceil($total / $limit);
-        for ($page = 1; $page < $pages + 1; $page++) {
-            $list = $this->find('all', array('fields' => $fields, 'conditions' => $conditions, 'limit' => $limit, 'page' => $page));
-            
-            foreach ($list as &$mark) {
-                if (!isset($data[$mark['EvaluationSimple']['evaluatee']])) {
-                    $data[$mark['EvaluationSimple']['evaluatee']]['user_id'] = $mark['EvaluationSimple']['evaluatee'];
-                    $data[$mark['EvaluationSimple']['evaluatee']]['score'] = $mark['EvaluationSimple']['score'];
-                    $data[$mark['EvaluationSimple']['evaluatee']]['numEval']= 1;
-                } else {
-                    $data[$mark['EvaluationSimple']['evaluatee']]['score'] += $mark['EvaluationSimple']['score'];
-                    $data[$mark['EvaluationSimple']['evaluatee']]['numEval']++;
-                }
+        $list = $this->find('all', array('fields' => $fields, 'conditions' => $conditions, 'contain' => false));
+        foreach ($list as $mark) {
+            if (!isset($data[$mark['EvaluationSimple']['evaluatee']])) {
+                $data[$mark['EvaluationSimple']['evaluatee']]['user_id'] = $mark['EvaluationSimple']['evaluatee'];
+                $data[$mark['EvaluationSimple']['evaluatee']]['score'] = $mark['EvaluationSimple']['score'];
+                $data[$mark['EvaluationSimple']['evaluatee']]['numEval']= 1;
+            } else {
+                $data[$mark['EvaluationSimple']['evaluatee']]['score'] += $mark['EvaluationSimple']['score'];
+                $data[$mark['EvaluationSimple']['evaluatee']]['numEval']++;
             }
         }
         //cleanup
@@ -538,7 +531,7 @@ class EvaluationSimple extends EvaluationResponseBase
         //$template = $simp->find('first', array('conditions' => array('SimpleEvaluation.id' => $event['Event']['template_id'])));
         //$max = $template['SimpleEvaluation']['point_per_member'];
 
-        foreach ($sub as &$stu) {
+        foreach ($sub as $stu) {
             if (isset($data[$stu['EvaluationSubmission']['submitter_id']])) {
                 $diff = strtotime($stu['EvaluationSubmission']['date_submitted']) - strtotime($event['Event']['due_date']);
                 $days = $diff/(60*60*24);
@@ -551,14 +544,14 @@ class EvaluationSimple extends EvaluationResponseBase
         //cleanup
         unset($sub);
 
-        foreach ($data as &$demo) {
+        foreach ($data as $demo) {
             if (!isset($demo['penalty'])) {
                 $data[$demo['user_id']]['penalty'] = 0;
             }
         }
 
         $grades = array();
-        foreach ($data as &$student) {
+        foreach ($data as $student) {
             $tmp = array();
             $tmp['id'] = 0;
             $tmp['evaluatee'] = $student['user_id'];

--- a/app/vendors/tcpdf/config/tcpdf_config.php
+++ b/app/vendors/tcpdf/config/tcpdf_config.php
@@ -239,7 +239,7 @@ if (!defined('K_TCPDF_EXTERNAL_CONFIG')) {
 	/**
 	 * set to true to enable the special procedure used to avoid the overlappind of symbols on Thai language
 	 */
-	define('K_THAI_TOPCHARS', true);
+	define('K_THAI_TOPCHARS', false);
 
 	/**
 	 * if true allows to call TCPDF methods using HTML syntax


### PR DESCRIPTION
- Improved performance to export CSV
- Improved Performance on PDF export although it still takes a long time for very large classes (recoding how the PDFs is generated is likely the only way to really fix it). 

Some Additional Performance changes for Grades API
- Further improved performance for simpleEvalScore and mixedEvalScore by removing the unneeded associated results from the query (no longer requires fetching in chunks)
- Further improved performance for rubricEvalScore by only fetching the EvaluationRubricDetail association (event is not needed)
- Added some documentation to rubricEvalScore for why it is fetching in chunks