### PR TITLE
Fixed #517 - Grades API now takes non-submitting user penalties into account

### DIFF
--- a/app/models/evaluation_mixeval.php
+++ b/app/models/evaluation_mixeval.php
@@ -434,9 +434,17 @@ class EvaluationMixeval extends EvaluationResponseBase
                 $diff = strtotime($stu['EvaluationSubmission']['date_submitted']) - strtotime($event['Event']['due_date']);
                 $days = $diff/(60*60*24);
                 $penalty = $pen->getPenaltyByPenaltiesAndDaysLate($penalties, $days);
-                //$penalty = $pen->getPenaltyByEventAndDaysLate($eventId, $days);
                 $data[$stu['EvaluationSubmission']['submitter_id']]['penalty'] = (isset($penalty['Penalty']['percent_penalty'])) ? $penalty['Penalty']['percent_penalty'] :
                         0;
+            } 
+        }
+        $end = strtotime($event['Event']['release_date_end']);
+        $now = time();
+        if ($now >= $end) {
+            $final_penalty = $pen->getPenaltyFinal($eventId);
+            $noSubmissions = array_diff(Set::extract($data, '/user_id'), Set::extract($sub, '/EvaluationSubmission/submitter_id'));
+            foreach ($noSubmissions as $userId) {
+                $data[$userId]['penalty'] = $final_penalty['Penalty']['percent_penalty'];
             }
         }
         //cleanup

--- a/app/models/evaluation_simple.php
+++ b/app/models/evaluation_simple.php
@@ -536,9 +536,17 @@ class EvaluationSimple extends EvaluationResponseBase
                 $diff = strtotime($stu['EvaluationSubmission']['date_submitted']) - strtotime($event['Event']['due_date']);
                 $days = $diff/(60*60*24);
                 $penalty = $pen->getPenaltyByPenaltiesAndDaysLate($penalties, $days);
-                //$penalty = $pen->getPenaltyByEventAndDaysLate($eventId, $days);
                 $data[$stu['EvaluationSubmission']['submitter_id']]['penalty'] = (isset($penalty['Penalty']['percent_penalty'])) ? $penalty['Penalty']['percent_penalty'] :
                         0;
+            }
+        }
+        $end = strtotime($event['Event']['release_date_end']);
+        $now = time();
+        if ($now >= $end) {
+            $final_penalty = $pen->getPenaltyFinal($eventId);
+            $noSubmissions = array_diff(Set::extract($data, '/user_id'), Set::extract($sub, '/EvaluationSubmission/submitter_id'));
+            foreach ($noSubmissions as $userId) {
+                $data[$userId]['penalty'] = $final_penalty['Penalty']['percent_penalty'];
             }
         }
         //cleanup

--- a/app/models/penalty.php
+++ b/app/models/penalty.php
@@ -141,15 +141,18 @@ class Penalty extends AppModel
     {
         if(empty($penalties) || 0.0 >= $daysLate) {
             return null;
-        } else {
-            $return_penalty = null;
-            foreach($penalties as $penalty) {
-                if($penalty["Penalty"]["days_late"] <= ceil($daysLate)) {
-                    $return_penalty = $penalty;
-                }
-            }
-            return $return_penalty;
         }
+        
+        $max_penalty = null;
+        foreach($penalties as $penalty) {
+            $max_penalty = $penalty;
+            //return first penalty that if above daysLate
+            if($penalty["Penalty"]["days_late"] >= $daysLate) {
+                return $penalty;
+            }
+        }
+        //else daysLate after last penalty so return max penalty
+        return $max_penalty;
     }
 
     function getPenaltyByEventSubmissionAndDue($eventId, $event_due, $submissionDate)

--- a/app/tests/cases/models/penalty.test.php
+++ b/app/tests/cases/models/penalty.test.php
@@ -141,6 +141,23 @@ class PenaltyTestCase extends CakeTestCase
         $ret = $this->Penalty ->getPenaltyByPenaltiesAndDaysLate($penalties, 5);
         $this->assertEqual($ret['Penalty']['percent_penalty'], 60);
         
+        // test inbetween penalties with several days between days late
+        // 1 day 15% to 4 days 60%
+        $penalties = array( $penalties['0'],  $penalties['3'] );
+        
+        // valid event between 1 amd 4 days
+        $ret = $this->Penalty->getPenaltyByPenaltiesAndDaysLate($penalties, 1);
+        $this->assertEqual($ret['Penalty']['percent_penalty'], 15);
+        $ret = $this->Penalty->getPenaltyByPenaltiesAndDaysLate($penalties, 1.5);
+        $this->assertEqual($ret['Penalty']['percent_penalty'], 60);
+        $ret = $this->Penalty->getPenaltyByPenaltiesAndDaysLate($penalties, 2.5);
+        $this->assertEqual($ret['Penalty']['percent_penalty'], 60);
+        $ret = $this->Penalty->getPenaltyByPenaltiesAndDaysLate($penalties, 3.5);
+        $this->assertEqual($ret['Penalty']['percent_penalty'], 60);
+        $ret = $this->Penalty->getPenaltyByPenaltiesAndDaysLate($penalties, 4);
+        $this->assertEqual($ret['Penalty']['percent_penalty'], 60);
+        
+        
         // valid empty event penalties set
         $penalties = $this->Penalty->getPenaltyByEventId(3);
         $this->assertEqual(empty($penalties), true);


### PR DESCRIPTION
- Simple Eval and Mixed Eval now take into account penalties for students who do not submit their evaluations (Rubric problem was addressed in #513)
- Fixed a range calculation issue with the getPenaltyByPenaltiesAndDaysLate function in Penalties Model (added case to unit tests) that I missed