### PR TITLE
Fix #527

### DIFF
--- a/app/controllers/components/export_base_new.php
+++ b/app/controllers/components/export_base_new.php
@@ -239,6 +239,25 @@ class ExportBaseNewComponent extends Object
                     // mixed evaluation
                     $results = $response[$this->detailModel[$event['Event']['event_template_type_id']]];
                     $results = Set::combine($results, '{n}.question_number', '{n}');
+                    
+                    $missing_required_question = false;
+                    
+                    foreach ($event['Question'] as $question) {
+                        if ($question['self_eval'] == $peerEval) {
+                            continue; // skip questions that don't belong in the desired section
+                        }
+                        if ($question['required'] && !isset($results[$question['question_num']])) {
+                            $missing_required_question = true;
+                        }
+                    }
+                    
+                    if ($missing_required_question) {
+                        //skip the rest of output
+                        $grid[] = $row;
+                        $yInc++;
+                        continue;
+                    }
+                    
                     foreach ($event['Question'] as $question) {
                         if ($question['self_eval'] == $peerEval) {
                             continue; // skip questions that don't belong in the desired section

--- a/app/controllers/v1_controller.php
+++ b/app/controllers/v1_controller.php
@@ -800,7 +800,7 @@ class V1Controller extends Controller {
         $statusCode = 'HTTP/1.1 400 Bad Request'; // unrecognized request type
 
         // initialize find parameters
-        $fields = array('id', 'evaluatee', 'score');
+        $fields = array('id', 'evaluatee', 'evaluator', 'score');
         $conditions = array('event_id' => $event_id);
         // add additional conditions if they only want 1 user
         if ($user_id) {

--- a/app/models/evaluation_mixeval.php
+++ b/app/models/evaluation_mixeval.php
@@ -408,25 +408,83 @@ class EvaluationMixeval extends EvaluationResponseBase
      function mixedEvalScore($eventId, $fields, $conditions) {
         $evalSub = ClassRegistry::init('EvaluationSubmission');
         $pen = ClassRegistry::init('Penalty');
+        $mixeval = ClassRegistry::init('Mixeval');
+        $event = $this->Event->find('first', array('conditions' => array('Event.id' => $eventId)));
+        
+        $sub = $evalSub->getEvalSubmissionsByEventId($eventId);
+        $submitted_user_ids = Set::extract('/EvaluationSubmission/submitter_id', $sub);
+        $partial_submission_user_ids = array();
 
         $data = array();
         
         $list = $this->find('all', array('fields' => $fields, 'conditions' => $conditions, 'contain' => false));
         foreach($list as $mark) {
-            if (!isset($data[$mark['EvaluationMixeval']['evaluatee']])) {
-                $data[$mark['EvaluationMixeval']['evaluatee']]['user_id'] = $mark['EvaluationMixeval']['evaluatee'];
-                $data[$mark['EvaluationMixeval']['evaluatee']]['score'] = $mark['EvaluationMixeval']['score'];
-                $data[$mark['EvaluationMixeval']['evaluatee']]['numEval']= 1;
+            $evaluator_id = $mark['EvaluationMixeval']['evaluator'];
+            $evaluatee_id = $mark['EvaluationMixeval']['evaluatee'];
+            $score = $mark['EvaluationMixeval']['score'];
+            
+            // if evaluator has only partially submitted results, 
+            // skip adding htier score for now
+            if (!in_array($evaluator_id, $submitted_user_ids)) {
+                $partial_submission_user_ids[] = $evaluator_id;
+                continue;
+            }
+            
+            if (!isset($data[$evaluatee_id])) {
+                $data[$evaluatee_id]['user_id'] = $evaluatee_id;
+                $data[$evaluatee_id]['score'] = $score;
+                $data[$evaluatee_id]['numEval']= 1;
             } else {
-                $data[$mark['EvaluationMixeval']['evaluatee']]['score'] += $mark['EvaluationMixeval']['score'];
-                $data[$mark['EvaluationMixeval']['evaluatee']]['numEval']++;
+                $data[$evaluatee_id]['score'] += $score;
+                $data[$evaluatee_id]['numEval']++;
+            }
+        }
+        
+        if (!empty($partial_submission_user_ids)) {
+            // get requried questions for event
+            $event_mixeval = $mixeval->find('first', array(
+                'conditions' => array('Mixeval.id' => $event['Event']['template_id']),
+                'recursive' => 2
+            ));
+            $required = Set::combine($event_mixeval['MixevalQuestion'], '{n}.question_num', '{n}.required');
+            $peerQues = Set::combine($event_mixeval['MixevalQuestion'], '{n}.question_num', '{n}.self_eval');
+            // only required peer evaluation questions are counted toward the averages
+            $required = array_intersect(array_keys($required, 1), array_keys($peerQues, 0));
+            
+            # get evalutation for partially submitted users with details
+            $partial_submission_user_ids = array_unique($partial_submission_user_ids);
+            $conditions['evaluator'] = $partial_submission_user_ids;
+            $list = $this->find('all', array('fields' => $fields, 'conditions' => $conditions, 'recursive' => 1 ));
+            foreach($list as $mark) {
+                $questions_evaluated = Set::extract('/EvaluationMixevalDetail/question_number', $mark);
+                $missing_required_question = false;
+                foreach ($required as $question_num) {
+                    if (!in_array($question_num, $questions_evaluated)) {
+                        $missing_required_question = true;
+                    }
+                }
+                // skip incomplete evaluatee submissions
+                if ($missing_required_question) {
+                    continue;
+                }
+                
+                $evaluatee_id = $mark['EvaluationMixeval']['evaluatee'];
+                $score = $mark['EvaluationMixeval']['score'];
+                
+                if (!isset($data[$evaluatee_id])) {
+                    $data[$evaluatee_id]['user_id'] = $evaluatee_id;
+                    $data[$evaluatee_id]['score'] = $score;
+                    $data[$evaluatee_id]['numEval']= 1;
+                } else {
+                    $data[$evaluatee_id]['score'] += $score;
+                    $data[$evaluatee_id]['numEval']++;
+                }
             }
         }
         //cleanup
         unset($list);
+        
 
-        $sub = $evalSub->getEvalSubmissionsByEventId($eventId);
-        $event = $this->Event->find('first', array('conditions' => array('Event.id' => $eventId)));
         $penalties = $pen->getPenaltyByEventId($eventId);
 
         foreach ($sub as $stu) {

--- a/app/tests/cases/components/evaluation_component.test.php
+++ b/app/tests/cases/components/evaluation_component.test.php
@@ -492,19 +492,20 @@ class EvaluationTestCase extends CakeTestCase
             ),
         );
         $include = array(5);
-        $eval = $this->EvaluationComponentTest->getMixevalResultDetail($groupEventId, $groupMembers, $include);
+        $required = array(1, 2, 3, 4, 5);
+        $eval = $this->EvaluationComponentTest->getMixevalResultDetail($groupEventId, $groupMembers, $include, $require);
         // Set up expected results
         $expected = $this->setUpMixevalResultDetail();
         $this->assertEqual($eval, $expected);
 
         // Null test cases
-        $eval = $this->EvaluationComponentTest->getMixevalResultDetail(null, $groupMembers, null);
+        $eval = $this->EvaluationComponentTest->getMixevalResultDetail(null, $groupMembers, null, null);
         $expected = array(
             "scoreRecords"=>array(),
             "evalResult"=> array(),
         );
         $this->assertEqual($eval, $expected);
-        $eval = $this->EvaluationComponentTest->getMixevalResultDetail(null, null, null);
+        $eval = $this->EvaluationComponentTest->getMixevalResultDetail(null, null, null, null);
         $this->assertEqual($eval, $expected);
 
     }

--- a/app/tests/cases/models/sys_parameter.test.php
+++ b/app/tests/cases/models/sys_parameter.test.php
@@ -64,7 +64,7 @@ class SysParameterTestCase extends CakeTestCase
     function testNumberSysParam()
     {
         $result = $this->SysParameter->find('count');
-        $this->assertEqual($result, 18);
+        $this->assertEqual($result, 19);
         
         $result = $this->SysParameter->find('list', array('fields' => array('SysParameter.parameter_code')));
         $expected = array(


### PR DESCRIPTION
Incomplete Mixed eval submissions now reflect same score across UI, API, and cvs exports

In a partially completed mixed evaluation submission:
    - If all required questions for a group member are completed, the submission's score will be counted for that group members
    - If any required questions are incomplete for a group member, the submission's score will not be counted for that group member