### PR TITLE
Fix edit event template issue

### DIFF
--- a/app/controllers/events_controller.php
+++ b/app/controllers/events_controller.php
@@ -601,40 +601,48 @@ class EventsController extends AppController
         $this->set('groups', $this->Group->getGroupsByCourseId($event['Event']['course_id']));
 
         // Populate the template selections
-        $this->set(
-            'mixevals',
-            $this->Mixeval->getBelongingOrPublic($this->Auth->user('id'))
-        );
-        $this->set(
-            'simpleEvaluations',
-            $this->SimpleEvaluation->getBelongingOrPublic($this->Auth->user('id'))
-        );
-        $this->set(
-            'surveys',
-            $this->Survey->getBelongingOrPublic($this->Auth->user('id'))
-        );
-        $this->set(
-            'rubrics',
-            $this->Rubric->getBelongingOrPublic($this->Auth->user('id'))
-        );
-        $this->set(
-            'eventTemplateTypes',
-            $this->EventTemplateType->getEventTemplateTypeList(true)
-        );
         $this->set('simpleSelected', '');
         $this->set('rubricSelected', '');
         $this->set('surveySelected', '');
         $this->set('mixevalSelected', '');
         $typeId = $event['Event']['event_template_type_id'];
+        $simpleSelected = NULL;
+        $rubricSelected = NULL;
+        $surveySelected = NULL;
+        $mixevalSelected = NULL;
         if ($typeId == 1) {
+            $simpleSelected = $event['Event']['template_id'];
             $this->set('simpleSelected', $event['Event']['template_id']);
         } else if ($typeId == 2) {
+            $rubricSelected = $event['Event']['template_id'];
             $this->set('rubricSelected', $event['Event']['template_id']);
         } else if ($typeId == 3) {
+            $surveySelected = $event['Event']['template_id'];
             $this->set('surveySelected', $event['Event']['template_id']);
         } else if ($typeId == 4) {
+            $mixevalSelected = $event['Event']['template_id'];
             $this->set('mixevalSelected', $event['Event']['template_id']);
         }
+        $this->set(
+            'mixevals',
+            $this->Mixeval->getBelongingOrPublic($this->Auth->user('id'), $mixevalSelected)
+        );
+        $this->set(
+            'simpleEvaluations',
+            $this->SimpleEvaluation->getBelongingOrPublic($this->Auth->user('id'), $simpleSelected)
+        );
+        $this->set(
+            'surveys',
+            $this->Survey->getBelongingOrPublic($this->Auth->user('id'), $surveySelected)
+        );
+        $this->set(
+            'rubrics',
+            $this->Rubric->getBelongingOrPublic($this->Auth->user('id'), $rubricSelected)
+        );
+        $this->set(
+            'eventTemplateTypes',
+            $this->EventTemplateType->getEventTemplateTypeList(true)
+        );
         $emailReminders = array('0'=> 'Disable', '1' => '1 Day', '2'=>'2 Days','3'=>'3 Days','4'=>'4 Days','5'=>'5 Days','6'=>'6 Days','7'=>'7 Days');
         $this->set('emailTemplates', $this->EmailTemplate->getPermittedEmailTemplate(User::get('id'), 'list'));
         $this->set('emailSchedules', $emailReminders);

--- a/app/models/evaluation_base.php
+++ b/app/models/evaluation_base.php
@@ -105,20 +105,32 @@ class EvaluationBase extends AppModel
     /**
      * getBelongingOrPublic
      * Returns the evaluations made by this user, and any other public ones.
+     * Optionally include an additional evaluation by id that bypasses ownership and public restrictions.
      *
      * @param mixed $user_id
+     * @param mixed $include_id
      *
      * @access public
      * @return void
      */
-    function getBelongingOrPublic($user_id)
+    function getBelongingOrPublic($user_id, $include_id=NULL)
     {
         if (!is_numeric($user_id)) {
             return false;
         }
 
-        $conditions = array('creator_id' => $user_id);
-        $conditions = array('OR' => array_merge(array('availability' => 'public'), $conditions));
+        if (!is_null($include_id) && !is_numeric($include_id)) {
+            return false;
+        }
+
+        $conditions = array(
+            'creator_id' => $user_id,
+            'availability' => 'public',
+        );
+        if (!is_null($include_id)) {
+            $conditions['id'] = $include_id;
+        }
+        $conditions = array('OR' => $conditions);
         return $this->find('list', array('conditions' => $conditions, 'fields' => array('name'), 'order' => 'name ASC'));
     }
 

--- a/app/models/mixeval.php
+++ b/app/models/mixeval.php
@@ -165,24 +165,36 @@ class Mixeval extends AppModel
     /**
      * getBelongingOrPublic
      * Returns the evaluations made by this user, and any other public ones.
+     * Optionally include an additional evaluation by id that bypasses ownership and public restrictions.
      *
      * Note duplicate in evaluation_base. Unfortunately, evaluation_base
      * causes other problems for some reason, so can't inherit from it, just
      * copy and pasting the code here for now.
      *
      * @param mixed $user_id
+     * @param mixed $include_id
      *
      * @access public
      * @return void
      */
-    function getBelongingOrPublic($user_id)
+    function getBelongingOrPublic($user_id, $include_id=NULL)
     {
         if (!is_numeric($user_id)) {
             return false;
         }
 
-        $conditions = array('creator_id' => $user_id);
-        $conditions = array('OR' => array_merge(array('availability' => 'public'), $conditions));
+        if (!is_null($include_id) && !is_numeric($include_id)) {
+            return false;
+        }
+
+        $conditions = array(
+            'creator_id' => $user_id,
+            'availability' => 'public',
+        );
+        if (!is_null($include_id)) {
+            $conditions['id'] = $include_id;
+        }
+        $conditions = array('OR' => $conditions);
         return $this->find('list', array('conditions' => $conditions, 'fields' => array('name'), 'order' => 'name'));
     }
 


### PR DESCRIPTION
Users can now edit events without losing template settings when the current template is private and doesn’t belong to the editing user.