### PR TITLE
Fix issues with the group sync with "Replace" strategy

### DIFF
--- a/app/views/groups/sync_canvas.ctp
+++ b/app/views/groups/sync_canvas.ctp
@@ -1,9 +1,9 @@
-<div id="syncCanvasWrapper"><?php 
+<div id="syncCanvasWrapper"><?php
 
 $javascript->link(Router::url('/js/synccanvas.js', true), false);
 
-if (is_null($canvasGroupCategoryId)) : 
-    
+if (is_null($canvasGroupCategoryId)) :
+
     echo $this->Form->create(null, array("id" => "syncCanvasForm", "class"=>"prepare", "url" => $formUrl ));
 
     if (!empty($courseId)) {
@@ -15,7 +15,7 @@ if (is_null($canvasGroupCategoryId)) :
         echo $this->Form->hidden('canvasCourse', array('value' => $canvasCourseId));
     }
     if (!empty($canvasCourses)) {
-        echo $this->Form->input("canvasCourse", array("label"=>"Canvas Course", "multiple" => false, "default" => $canvasCourseId, "disabled"=>!empty($canvasCourseId)));        
+        echo $this->Form->input("canvasCourse", array("label"=>"Canvas Course", "multiple" => false, "default" => $canvasCourseId, "disabled"=>!empty($canvasCourseId)));
     }
     else {
         echo '<div class="input select">' . $this->Form->label("Canvas Course") . '</div>';
@@ -23,7 +23,7 @@ if (is_null($canvasGroupCategoryId)) :
         echo $this->Form->hidden('canvasCourse', array('value' => $canvasCourseId));
     }
 
-    if (!empty($courseId) && !empty($canvasCourseId)) : 
+    if (!empty($courseId) && !empty($canvasCourseId)) :
 
         echo $this->Form->input("canvasGroupCategory", array("label"=>"Canvas Group set", "multiple" => false));
 
@@ -32,17 +32,17 @@ if (is_null($canvasGroupCategoryId)) :
     ?><label class="defLabel"></label><?php
     echo $this->Form->submit(__("Next", true), array("class" => "button-next"));
     echo $this->Form->end();
-    
-else: 
+
+elseif (empty($disableSync)):
 
     echo $this->Form->create(null, array("id" => "syncCanvasForm", "class"=>"sync-screen", "url" => $formUrl));
 
-    if (!empty($groupsAndUsers)) { 
+    if (!empty($groupsAndUsers)) {
         echo $this->Form->input('formType', array(
             'legend' => false,
             'div' => array('id' => 'syncFormType'),
             'options' => array(
-                'simplified' => 'Simplified', 
+                'simplified' => 'Simplified',
                 'advanced'   => 'Advanced'
             ),
             'disabled' => (!$enableSimplifiedSync ? 'disabled' : false),
@@ -84,13 +84,13 @@ else:
             <tr>
                 <td colspan="3" class="non-existent-group">
                     <p>You do not have any groups in the selected iPeer course or Canvas course group set.</p>
-                    <p>You can create some groups <a href="/groups/index/<?php echo $courseId; ?>">in this iPeer course</a> or 
-                        <a href="<?php echo $canvasBaseUrl; ?>/courses/<?php echo $canvasCourseId; ?>/groups/#tab-<?php echo $canvasGroupCategoryId; ?>">in this Canvas course group set</a> 
+                    <p>You can create some groups <a href="/groups/index/<?php echo $courseId; ?>">in this iPeer course</a> or
+                        <a href="<?php echo $canvasBaseUrl; ?>/courses/<?php echo $canvasCourseId; ?>/groups/#tab-<?php echo $canvasGroupCategoryId; ?>">in this Canvas course group set</a>
                         and come back here to sync.</p>
                 </td>
             </tr>
 
-        <?php } else { 
+        <?php } else {
 
             foreach ($groupsAndUsers as $row) { ?>
 
@@ -127,9 +127,9 @@ else:
                                     <?php if (count($row['Member']) > $numMembersToShow): ?>
                                         <tr class="showMoreLessMembers">
                                             <td>
-                                                <a href="#" class="showMinMembers" style="display:none;">show <?php echo $numMembersToShow; ?></a> &nbsp; 
-                                                <a href="#" class="showLessMembers" style="display:none;">show less</a> &nbsp; 
-                                                <a href="#" class="showMoreMembers">show more</a> &nbsp; 
+                                                <a href="#" class="showMinMembers" style="display:none;">show <?php echo $numMembersToShow; ?></a> &nbsp;
+                                                <a href="#" class="showLessMembers" style="display:none;">show less</a> &nbsp;
+                                                <a href="#" class="showMoreMembers">show more</a> &nbsp;
                                                 <a href="#" class="showAllMembers">show all</a>
                                             </td>
                                         </tr>
@@ -156,7 +156,7 @@ else:
                             &rarr;
                         <?php else: ?>
                             &larr;
-                        <?php endif; ?>    
+                        <?php endif; ?>
                     </td>
                     <td>
                         <?php if (isset($row['CanvasGroup'])): ?>
@@ -190,9 +190,9 @@ else:
                                 <?php if (count($row['CanvasMember']) > $numMembersToShow): ?>
                                     <tr class="showMoreLessMembers">
                                         <td>
-                                            <a href="#" class="showMinMembers" style="display:none;">show <?php echo $numMembersToShow; ?></a> &nbsp; 
-                                            <a href="#" class="showLessMembers" style="display:none;">show less</a> &nbsp; 
-                                            <a href="#" class="showMoreMembers">show more</a> &nbsp; 
+                                            <a href="#" class="showMinMembers" style="display:none;">show <?php echo $numMembersToShow; ?></a> &nbsp;
+                                            <a href="#" class="showLessMembers" style="display:none;">show less</a> &nbsp;
+                                            <a href="#" class="showMoreMembers">show more</a> &nbsp;
                                             <a href="#" class="showAllMembers">show all</a>
                                         </td>
                                     </tr>
@@ -254,7 +254,7 @@ else:
     <?php echo $this->Form->hidden('syncType'); ?>
 
     <br>
-    
+
 <?php  echo $this->Form->end();
 
 endif; ?>

--- a/app/webroot/css/ipeer.css
+++ b/app/webroot/css/ipeer.css
@@ -7,8 +7,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
     margin: 0;
@@ -19,7 +19,7 @@ time, mark, audio, video {
     color: #333;
 }
 /* html5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
     display: block;
 }
@@ -75,13 +75,13 @@ p {
 }
 
 .pagewidth {
-    /* 780px is Wide enough for someone with a 800px device to 
+    /* 780px is Wide enough for someone with a 800px device to
      * view the whole app without horizontal scrolling. I assume
      * most people's computers are at least 1024x768. However
      * many smartphones have at least a 800x480 display now,
      * so we shouldn't use a higher min width.
      * */
-    min-width: 780px; 
+    min-width: 780px;
     max-width: 1000px;
     margin-left: auto;
     margin-right: auto;
@@ -116,9 +116,9 @@ p {
 }
 
 input[type="text"], input[type="file"], input[type="password"], textarea, select, button
-{   
-    margin: 0.35em 0.35em; 
-    border-radius: 3px; 
+{
+    margin: 0.35em 0.35em;
+    border-radius: 3px;
     border: 1px solid #999;
     clear: right;
     padding: 0.3em 0.5em;
@@ -200,7 +200,7 @@ strong {
     text-align: center;
 }
 
-.standardtable tr th:first-child, 
+.standardtable tr th:first-child,
 .standardtable tr td:first-child {
     border-left: none;
 }
@@ -245,8 +245,8 @@ div.ui-datepicker { font-size: 0.85em; }
 
 /* BANNER */
 .banner {
-    border-top-left-radius: 8px; 
-    border-top-right-radius: 8px; 
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
     border-bottom: none;
     background-color: #fff;
 }
@@ -277,7 +277,7 @@ div.ui-datepicker { font-size: 0.85em; }
 }
 
 #bannerLogoText {
-    font-size: 1em; 
+    font-size: 1em;
     font-weight: 200;
     font-style: italic;
 }
@@ -332,7 +332,7 @@ a#home, a#home:hover, a#home:active {
 }
 
 .navigation #current a,
-.navigation a:hover, 
+.navigation a:hover,
 .navigation a:active {
     background: none;
     border-bottom: solid 3px gold;
@@ -348,7 +348,7 @@ a#home, a#home:hover, a#home:active {
 
 /* CONTENT CONTAINER */
 .containerOuter {
-    border-radius: 10px; 
+    border-radius: 10px;
     border: 1px solid #ccc;
     padding: 2em;
     background: white;
@@ -360,9 +360,10 @@ a#home, a#home:hover, a#home:active {
     margin-top: 0.5em;
     margin-bottom: 1em;
     clear: left;
-    padding: 0.7em;
+    padding: 0.7em 1.2em;
     font-weight: 600;
     text-align: center;
+    line-height: 1.5em;
 }
 
 .good-message {
@@ -370,8 +371,8 @@ a#home, a#home:hover, a#home:active {
 }
 
 /* authMessage is only used for cake generated login errors. */
-#flashMessage, 
-#authMessage, 
+#flashMessage,
+#authMessage,
 .error-message {
     color: #990044;
     border: 1px solid #ca4343;
@@ -386,16 +387,25 @@ a#home, a#home:hover, a#home:active {
 .success-message > *,
 .good-message > * {
     text-align: left;
+    font-weight: 400;
 }
 
 #flashMessage > ul,
 #authMessage > ul,
 .error-message > ul,
-.success-message > ul
+.success-message > ul,
 .good-message > ul {
     list-style-type: disc;
     padding-left: 2em;
     padding-bottom: 1em;
+}
+
+#flashMessage > h2:first-child,
+#authMessage > h2:first-child,
+.error-message > h2:first-child,
+.success-message > h2:first-child,
+.good-message > h2:first-child {
+    margin-top: 0.5em;
 }
 
 #flashMessage > p,
@@ -406,7 +416,7 @@ a#home, a#home:hover, a#home:active {
     padding-top: 0;
 }
 
-#authMessage.success, 
+#authMessage.success,
 .success-message,
 .good-message {
     color: #159900;
@@ -515,7 +525,7 @@ i {
 }
 
 .login h4 {
-    background-color: crimson; 
+    background-color: crimson;
     color: white;
     margin: 0;
     padding: 0.5em;
@@ -647,15 +657,15 @@ i {
 
 /* view */
 
-#EmailtemplateViewForm .text input { 
+#EmailtemplateViewForm .text input {
     width: 21em;
 }
 
-#EmailtemplateViewForm .textarea textarea { 
+#EmailtemplateViewForm .textarea textarea {
     width: 21.5em;
 }
 
-#EmailtemplateViewForm .radio input { 
+#EmailtemplateViewForm .radio input {
     margin: 0.65em;
 }
 
@@ -677,12 +687,12 @@ i {
 }
 
 /* makes the text boxes bigger */
-#EmailtemplateAddForm .text input { 
+#EmailtemplateAddForm .text input {
     width: 21em;
 }
 
 
-#EmailtemplateAddForm .textarea textarea { 
+#EmailtemplateAddForm .textarea textarea {
     width: 21.5em;
 }
 
@@ -1090,9 +1100,9 @@ i {
     margin-bottom: 0.5em;
 }
 
-#Events .text label, #Events .password label, 
-#Events .textarea label, #Events .select label, 
-#Events .datetime label, #Events .radio legend, 
+#Events .text label, #Events .password label,
+#Events .textarea label, #Events .select label,
+#Events .datetime label, #Events .radio legend,
 #Events .penaltyLabel{
     width: 18em;
 }
@@ -1150,8 +1160,8 @@ i {
 }
 
 /* SysParameters */
-#sysParam .text label, 
-#sysParam .password label, 
+#sysParam .text label,
+#sysParam .password label,
 #sysParam .select label {
     width: 18em;
 }
@@ -1247,14 +1257,14 @@ i {
 
 #ajaxListDiv .timestamp {
     font-size: 0.8em;
-    text-align: left; 
+    text-align: left;
     width: 33%;
 }
 
 #ajaxListDiv .total-result {
-    text-align: center;  
-    width: 33%; 
-    font-weight: 600; 
+    text-align: center;
+    width: 33%;
+    font-weight: 600;
     font-size: 100%
 }
 
@@ -1997,7 +2007,7 @@ table.content-table {
     margin: 0 auto 0 auto;
 }
 
-.add-button, .delete-button, .edit-button, .merge-button, .export-excel-button, .compare-button, .instruction-icon, .button, 
+.add-button, .delete-button, .edit-button, .merge-button, .export-excel-button, .compare-button, .instruction-icon, .button,
 input[type="submit"], input[type="button"], button {
     background-color: #e6e6e6;
     padding: 5px 5px 5px 25px;
@@ -2136,7 +2146,7 @@ button:hover {
 
 textarea.question-title-textarea, textarea.question-descriptor {
     width: 90%;
-    height: 4em; 
+    height: 4em;
 }
 
 .question-title {
@@ -2210,7 +2220,7 @@ ul.instructions {
 }
 
 ul.instructions li {
-    list-style-type: square; 
+    list-style-type: square;
     padding: 0.2em;
 }
 


### PR DESCRIPTION
Fix issues with the group sync when choosing "Replace group rather than merge" flag

- Update both import and export logic and also do some refactoring
- For import, ensure Canvas group is seen as empty if it contains only ineligible members (i.e. members not in iPeer)
- For import, fix an issue with merging the imported non-empty groups with imported empty groups
- For export, if update flag is on, delete all the groups in canvas right away to allow users that are in other groups to be exported (if in only 1 iPeer group)
- For export, check group memberships when exporting each group (mainly code refactoring)
- Fix an issue when sync was not working as expected when group names are numeric
- Improve error messages

Closes: #556 