### PR TITLE
Clear question comment for graded questions

### DIFF
--- a/app/controllers/components/evaluation.php
+++ b/app/controllers/components/evaluation.php
@@ -1095,6 +1095,8 @@ class EvaluationComponent extends Object
                 if ($ques['required'] && !$ques['self_eval']) {
                     $totalGrade += $evalMixevalDetail['EvaluationMixevalDetail']['grade'];
                 }
+                // empty the comment for type 1 and 4 questions
+                $evalMixevalDetail['EvaluationMixevalDetail']['question_comment'] = NULL;
             } else {
                 if (empty($data[$num]['question_comment']) && !empty($evalMixevalDetail)) {
                     $this->EvaluationMixevalDetail->delete($this->EvaluationMixevalDetail->id);


### PR DESCRIPTION
For Mixed evaluation, clear the comment field if the question type is graded Likert or ScoreDropdown.

Cannot recreate the exact situation of having an entry in `evaluation_mixeval_details` with both `question_comment` and `grade`.  The case could be a data issue that the evaluation template was changed.  Nevertheless, added logic to clear the `question_comment` field when the evaluation is of grade types (Likert or ScoreDropdown).

Closes #565 