### PR TITLE
Fix progress bar for pushing grades to Canvas

### DIFF
--- a/app/views/evaluations/export_canvas.ctp
+++ b/app/views/evaluations/export_canvas.ctp
@@ -53,7 +53,7 @@ else if ($canvasProgressId) { ?>
     });
 
     function updateProgressbar() {
-        jQuery.get('<?php echo '/'.$this->params['url']['url'] . '/' . $canvasProgressId; ?>', function( data ) {
+        jQuery.get('<?php echo Router::url(null, false) . '/' . $canvasProgressId; ?>', function( data ) {
             jQuery('#export-progressbar').css('width', data.completion + '%');
             if (data.workflow_state == 'queued' || data.workflow_state == 'running') {
                 setTimeout(updateProgressbar, 500);


### PR DESCRIPTION
Fix the issue of progress bar not updated when pushing grades to Canvas. Caused by additional slash found at the start of the url in params['url']['url'] when running in the ipeerverf environment.

Change to use Router::url instead.