### PR TITLE
Sync instructors and TAs with Canvas

### DIFF
--- a/app/controllers/components/canvas_course_user.php
+++ b/app/controllers/components/canvas_course_user.php
@@ -30,6 +30,24 @@ class CanvasCourseUserComponent extends Object
     public $enrollment_roles = array();
 
     /**
+     * Finds the corresponding iPeer user with specific role
+     */
+    public static function getCorrespondingUser($currentUser, $canvas_course_users, $role)
+    {
+        $result = array();
+        foreach ($canvas_course_users as $ccuser) {
+            if (in_array($role, $ccuser->enrollment_roles)) {
+                $iuser = $ccuser->getMatchingiPeerUser($currentUser);
+
+                if ($iuser) {
+                    $result[$iuser['id']] = $iuser;
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
      * __construct
      *
      * @param mixed $args key -> value mappings to initialize the instance
@@ -64,7 +82,7 @@ class CanvasCourseUserComponent extends Object
             }
         }
     }
-    
+
     /**
      * Retrieves the corresponding iPeer User based on Canva user. null if not found.
      *

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -614,8 +614,12 @@ class User extends AppModel
      * @access public
      * @return array result
      * */
-    function addUserByArray($userList, $updateExisting = false)
+    function addUserByArray($userList, $updateExisting = false, $role_id=null)
     {
+        if (is_null($role_id)) {
+            $role_id = $this->USER_TYPE_STUDENT;
+        }
+
         $data = array();
 
         foreach ($userList as $line => $u) {
@@ -655,7 +659,7 @@ class User extends AppModel
 
             $tmp['creator_id']   = User::get('id');
             $data[$u[User::IMPORT_USERNAME]]['User'] = $tmp;
-            $data[$u[User::IMPORT_USERNAME]]['Role']['RolesUser']['role_id'] = '5';
+            $data[$u[User::IMPORT_USERNAME]]['Role']['RolesUser']['role_id'] = $role_id;
         }
 
         if (!count($data)) {
@@ -726,7 +730,7 @@ class User extends AppModel
             }
         }
 
-        return array('created_students' => $data, 'updated_students' => $existings);
+        return array('created_users' => $data, 'updated_users' => $existings);
     }
 
     /**

--- a/app/tests/cases/system/canvas_integration.test.php
+++ b/app/tests/cases/system/canvas_integration.test.php
@@ -304,7 +304,7 @@ class CanvasIntegrationTestCase extends SystemBaseTestCase
     private function _ipeerImportStudentFromCanvas($canvasUser, $canvasPassword, $courseCode, $courseTitle, $canvasCourseTitle, $createdStudent, $updatedStudent)
     {
         $this->_ipeerCourseHome($courseTitle);
-        $this->session->elementWithWait(PHPWebDriver_WebDriverBy::XPATH, '//a[text()="Import Students from Canvas"]')->click();
+        $this->session->elementWithWait(PHPWebDriver_WebDriverBy::XPATH, '//a[text()="Import Users from Canvas"]')->click();
         $this->_handleOAuth($canvasUser, $canvasPassword);
         
         // the iPeer course should be selecte by default

--- a/app/views/courses/edit.ctp
+++ b/app/views/courses/edit.ctp
@@ -45,7 +45,7 @@ echo $html->div('help-text', __('Course title, e.g. Technical Communication', tr
 function makeInstructor($i, $userId, $fullName, $html, $form) {
     // make instructor text box
     $name = "'$fullName'";
-    $input = $form->label(' ') . $form->text("Instructor.$i.full_name", array('default' => $fullName, 'disabled' => true)) .
+    $input = $form->label(' ') . $form->text("Instructor.$i.full_name", array('value' => $fullName, 'disabled' => true)) .
         $html->link('X', '#', array('onclick' => "rmInstructor($i, $name, $userId); return false;"));
     $input .= $form->hidden("Instructor.Instructor.$i", array('value' => $userId));
     $ret = $html->div('input text', $input, array('id' => "instructorsList$i"));
@@ -63,7 +63,10 @@ if (isset($this->data) && isset($this->data['Instructor'])) {
     // eg. admin adds an instructor from a different department to the course.
     $profs = Set::combine($this->data['Instructor'], '{n}.id', '{n}.full_name');
     foreach($this->data['Instructor']['Instructor'] as $key => $id) {
-        $prof .= makeInstructor($key, $id, $profs[$id], $html, $form);
+        // Lookup the fullname in $profs or $instructors
+        // In some cases (e.g. add a new course and encounterd error, need to show the add screen again),
+        // $profs is not propulated with names
+        $prof .= makeInstructor($key, $id, array_key_exists($id, $profs)? $profs[$id] : $instructors[$id], $html, $form);
         $numInstructors = $key + 1;
         $selected[] = $id;
     }

--- a/app/views/elements/courses/submenu.ctp
+++ b/app/views/elements/courses/submenu.ctp
@@ -75,7 +75,7 @@ switch($submenu) {
     if ($canvasEnabled){
         array_push(
             $items,
-            array('name' => 'Import Students from Canvas',  'link' => "/users/import/$course_id/canvas")
+            array('name' => 'Import Users from Canvas',  'link' => "/users/import/$course_id/canvas")
         );
         array_push(
             $items,

--- a/app/views/users/import.ctp
+++ b/app/views/users/import.ctp
@@ -22,6 +22,14 @@
         user3,first3,last3,student3,3@example.com,password3
         user4,first4,last4,student4,4@example.com,password4
         </pre>
+    <?php else: ?>
+        <ul>
+            <li><?php __("This function will import instructors, TAs, and students from corresponding Canvas course")?></li>
+            <li><?php __("TAs in Canvas will be imported as instructors for the course")?></li>
+            <li><?php __("Instructors / TAs with existing iPeer accounts but not with Primary Role as Instructor will NOT be imported")?></li>
+            <li><?php __("Existing students in the iPeer course will be removed and a fresh roster is imported from Canvas")?></li>
+            <li><?php __("Existing instructors / TAs in the iPeer course will be kept and merged with those imported from Canvas")?></li>
+        </ul>
     <?php endif; ?>
 
 <h2><?php __('Import')?></h2>
@@ -39,7 +47,9 @@ else {
 }
 echo $this->Form->input('Course', array('label'=>'Into iPeer Course', 'multiple' => false, 'default' => $courseId, 'disabled' => 'disabled'));
 echo $this->Form->hidden('Course', array('value' => $courseId));
-echo $this->Form->input('update_class', array('label'=>'Remove old students', 'type'=>'checkbox'));
+if ($isFileImport) {
+    echo $this->Form->input('update_class', array('label'=>'Remove old students', 'type'=>'checkbox'));
+}
 echo $this->Form->submit(__('Import', true));
 echo $this->Form->end();
 ?>

--- a/app/views/users/user_summary.ctp
+++ b/app/views/users/user_summary.ctp
@@ -5,16 +5,39 @@
 
   <?php $msg = ('resetPassword' == $this->action || 'edit' == $this->action) ? __('User(s) modified successfully:', true) : __('User(s) created successfully:', true);?>
 
-  <?php if (isset($data['created_students'])) : ?>
+  <?php if (isset($data['created_users'])) : ?>
     <h3><?php echo $msg?></h3>
-    <?php echo $this->element('users/user_summary_list', array('data'=>$data['created_students'], 'showPasswords' => (isset($showPasswords) ? $showPasswords : true) ));?>
+    <?php echo $this->element('users/user_summary_list', array('data'=>$data['created_users'], 'showPasswords' => (isset($showPasswords) ? $showPasswords : true) ));?>
   <?php endif; ?>
 
   <?php $msg = ('resetPassword' == $this->action || 'edit' == $this->action) ? __('User(s) modified successfully:', true) : __('User(s) updated successfully:', true);?>
 
-  <?php if (isset($data['updated_students'])) : ?>
+  <?php if (isset($data['updated_users'])) : ?>
     <h3><?php echo $msg?></h3>
-    <?php echo $this->element('users/user_summary_list', array('data'=>$data['updated_students']));?>
+    <?php echo $this->element('users/user_summary_list', array('data'=>$data['updated_users']));?>
+  <?php endif; ?>
+
+  <?php if (!empty($dataInstructors)) : ?>
+      <p>
+      <!-- instructors / TAs -->
+      <?php if (isset($dataInstructors['failed_users']) && !empty($dataInstructors['failed_users'])) : ?>
+        <h3><?php __('Instructor(s)/TA(s) failed to add to the course.  Please check their Primary Role:')?></h3>
+        <?php echo $this->element('users/user_summary_list', array('data'=>$dataInstructors['failed_users']));?>
+      <?php endif; ?>
+
+      <?php $msg = ('resetPassword' == $this->action || 'edit' == $this->action) ? __('Instructor(s)/TA(s) modified successfully:', true) : __('Instructor(s)/TA(s) created successfully:', true);?>
+
+      <?php if (isset($dataInstructors['created_users'])) : ?>
+        <h3><?php echo $msg?></h3>
+        <?php echo $this->element('users/user_summary_list', array('data'=>$dataInstructors['created_users'], 'showPasswords' => (isset($showPasswords) ? $showPasswords : true) ));?>
+      <?php endif; ?>
+
+      <?php $msg = ('resetPassword' == $this->action || 'edit' == $this->action) ? __('Instructor(s)/TA(s) modified successfully:', true) : __('Instructor(s)/TA(s) updated successfully:', true);?>
+
+      <?php if (isset($dataInstructors['updated_users'])) : ?>
+        <h3><?php echo $msg?></h3>
+        <?php echo $this->element('users/user_summary_list', array('data'=>$dataInstructors['updated_users']));?>
+      <?php endif; ?>
   <?php endif; ?>
 
 <p>


### PR DESCRIPTION
- Pre-select both Canvas instructors and TAs as iPeer instructors
when creating a new course based on a Canvas course. Only existing iPeer
instructors will be pre-selected.

- Import instructors and TAs when importing class roster

- When importing from Canvas, always drop existing iPeer students from the course before importing

Closes #554 