### PR TITLE
Simplify Canvas group import and export

### DIFF
--- a/app/controllers/courses_controller.php
+++ b/app/controllers/courses_controller.php
@@ -54,7 +54,7 @@ class CoursesController extends AppController
         $this->FileUpload->fileModel(null);
         $this->FileUpload->attr('required', true);
         $this->FileUpload->attr('forceWebroot', false);
-        
+
         $this->canvasEnabled = in_array($this->SysParameter->get('system.canvas_enabled', 'false'), array('1', 'true', 'yes'));
         $this->set('canvasEnabled', $this->canvasEnabled);
     }
@@ -205,6 +205,7 @@ class CoursesController extends AppController
 
         $this->set('data', $course);
         $this->set('title_for_layout', $course['Course']['full_name']);
+        $this->set('canvasEnabled', in_array($this->SysParameter->get('system.canvas_enabled', 'false'), array('1', 'true', 'yes')));
 
         //Setup the courseId to session
         $this->Session->write('ipeerSession.courseId', $id);
@@ -268,7 +269,7 @@ class CoursesController extends AppController
         $this->set('instructors', $instructorList);
         $this->set('tutors', $tutorList);
     }
-    
+
     /**
      * Finds the corresponding iPeer user with specific role
      */
@@ -286,7 +287,7 @@ class CoursesController extends AppController
         }
         return $result;
     }
-    
+
     /**
      * Retrieves course data from Canvas and populate into $this->data
      */
@@ -297,7 +298,7 @@ class CoursesController extends AppController
        if (!empty($selectedCanvasCourse)) {
            $this->data['Course']['course'] = $selectedCanvasCourse->course_code;
            $this->data['Course']['title'] = $selectedCanvasCourse->name;
-           
+
            $canvasusers = $selectedCanvasCourse->getUsers(
                $this, User::get('id'),
                array(CanvasCourseUserComponent::ENROLLEMNT_QUERY_TA, CanvasCourseUserComponent::ENROLLMENT_QUERY_TEACHER));
@@ -309,7 +310,7 @@ class CoursesController extends AppController
            $this->data['Tutor']['Tutor'] = array_keys($iTAs);
        }
    }
-    
+
     /**
      * add
      *
@@ -322,12 +323,12 @@ class CoursesController extends AppController
         $this->_initFormEnv();
         $this->set('instructorSelected', User::get('id'));
         $this->set('canvasCourses', array());
-        
+
         $instructions = $this->SysParameter->find('first', array('conditions' => array('parameter_code' => 'course.creation.instructions')));
         if (!empty($instructions) && !empty($instructions['SysParameter']['parameter_value'])) {
             $this->set('instructions', $instructions['SysParameter']['parameter_value']);
         }
-        
+
         if ($selCanvas === 'selCanvas') {
             if ($this->canvasEnabled){
                 // map function to keep only the course name
@@ -359,7 +360,7 @@ class CoursesController extends AppController
                 $this->redirect('index');
             }
         }
-        
+
         if (!empty($this->data)) {
             $this->data['Course'] = array_map('trim', $this->data['Course']);
             if ($this->Course->save($this->data)) {
@@ -397,14 +398,14 @@ class CoursesController extends AppController
     public function edit($courseId)
     {
         $this->_initFormEnv($courseId);
-        
+
         $course = $this->Course->getAccessibleCourseById($courseId, User::get('id'), User::getCourseFilterPermission(), array('Instructor', 'Department'));
         if (!$course) {
             $this->Session->setFlash(__('Error: Course does not exist or you do not have permission to view this course.', true));
             $this->redirect('index');
             return;
         }
-      
+
         if ($this->canvasEnabled) {
             // map function to keep only the course name
             $map_func = function($value) {
@@ -441,7 +442,7 @@ class CoursesController extends AppController
         $course['Instructor']['Instructor'] = Set::extract('/Instructor/id', $course);
         $tutors = $this->UserTutor->findAllByCourseId($courseId);
         $course['Tutor']['Tutor'] = Set::extract('/UserTutor/user_id', $tutors);
-        
+
         $this->data = $course;
         $this->set('breadcrumb', $this->breadcrumb->push(array('course' => $course['Course']))->push(__('Edit Course', true)));
     }
@@ -778,7 +779,7 @@ class CoursesController extends AppController
             $this->Session->setFlash(__('Error: Course does not exist or you do not have permission to view this course.', true));
             $this->redirect('index');
         }
-        
+
         // if selected students to enroll
         if (!empty($this->data['Course']['enroll_by_canvas'])) {
             $this->Course->enrolStudents($this->data['Course']['enroll_by_canvas'],
@@ -789,11 +790,11 @@ class CoursesController extends AppController
             $this->Course->unenrolStudents($this->data['Course']['unenroll'],
                 $courseId);
         }
-        
+
         $course = $this->Course->getCourseWithEnrolmentById($courseId);
         $this->set('courseId', $courseId);
         $canvasCourseId = $course['Course']['canvas_id'];
-        
+
         // Canvas courses that the user can access
         $canvasCourses = CanvasCourseComponent::getAllByIPeerUser($this, User::get('id'), true);
         $selectedCanvasCourse =

--- a/app/views/courses/home.ctp
+++ b/app/views/courses/home.ctp
@@ -68,6 +68,13 @@ if (User::hasPermission('controllers/Surveys')) {
   echo $this->element('courses/submenu', $params);
 }
 
+if ($canvasEnabled) {
+  $submenu = 'Canvas';
+  $submenuTitle = __('Canvas', true);
+  $params = array('controller'=>'courses', 'submenu'=>$submenu, 'submenuTitle'=>$submenuTitle, 'course_id'=>$data['Course']['id']);
+  echo $this->element('courses/submenu', $params);
+}
+
 ?>
 </div>
 </div>

--- a/app/views/elements/courses/submenu.ctp
+++ b/app/views/elements/courses/submenu.ctp
@@ -19,12 +19,6 @@ switch($submenu) {
             array('name' => 'Email to All Students',  'link' => "/emailer/write/C/$course_id"),
             array('name' => 'Import Students from CSV', 'link' => "/users/import/$course_id")
         );
-        if ($canvasEnabled){
-            array_push(
-                $items,
-                array('name' => 'Import Students from Canvas',  'link' => "/users/import/$course_id/canvas")
-            );
-        }
     }
     break;
   case "Group":
@@ -43,12 +37,6 @@ switch($submenu) {
         $items,
         array('name' => 'Export Groups to CSV', 'link' => "/groups/export/$course_id")
     );
-    if ($canvasEnabled){
-        array_push(
-            $items,
-            array('name' => 'Sync Canvas Groups', 'link' => "/groups/syncCanvas/$course_id")
-        );
-    }
     break;
   case "EvalEvents":
     if ($status == 'A') {
@@ -83,9 +71,29 @@ switch($submenu) {
         array('name' => 'Export Survey Group Sets', 'link' => "/surveygroups/export/$course_id")
     );
     break;
+  case "Canvas":
+    if ($canvasEnabled){
+        array_push(
+            $items,
+            array('name' => 'Import Students from Canvas',  'link' => "/users/import/$course_id/canvas")
+        );
+        array_push(
+            $items,
+            array('name' => 'Import Groups from Canvas', 'link' => "/groups/import/$course_id/canvas")
+        );
+        array_push(
+            $items,
+            array('name' => 'Export iPeer Groups to Canvas', 'link' => "/groups/export/$course_id/canvas")
+        );
+        // array_push(
+        //     $items,
+        //     array('name' => 'Sync Canvas Groups', 'link' => "/groups/syncCanvas/$course_id")
+        // );
+    }
+    break;
 }
 ?>
-<div class="course_submenu">
+<div class="course_submenu course_submenu-<?php echo $submenu; ?>">
 <h3>
   <?php echo $submenuTitle?>
 </h3>

--- a/app/views/groups/export.ctp
+++ b/app/views/groups/export.ctp
@@ -1,3 +1,5 @@
+<?php if ($exportTo == 'file'): ?>
+
 <?php echo $html->script('groups');?>
 <div class="content-container">
     <form name="frm" id="frm" method="POST" action="<?php echo $html->url('export/'.$courseId) ?>">
@@ -58,3 +60,53 @@ echo $this->element("groups/group_list_chooser",
       </table>
     </form>
 </div>
+
+<?php elseif (!empty($exportSuccess)): ?>
+
+    <br><br>
+    <p><a href="/courses/home/<?php echo $courseId; ?>">&laquo; Back to course homepage</a></p>
+
+<?php else: ?>
+
+<div class="instructions">
+
+When you press the Export button below:
+    <ul class="bulleted-list">
+        <li><?php __('All the groups in the selected Canvas group set will be deleted.')?></li>
+        <li><?php __('The groups in this iPeer course will be exported to the selected group set in Canvas, along with their members.')?></li>
+        <li><?php __('Any students in iPeer that are not in Canvas will not be exported.')?></li>
+    </ul>
+
+</div>
+
+    <br><br>
+
+Export groups to: <br><br>
+    <?php
+    echo $this->Form->create(null, array("id" => "syncCanvasForm", "class"=>"prepare", "url" => $formUrl ));
+
+    echo $this->Form->hidden('Course', array('value' => $courseId));
+
+    if (!empty($canvasCourseId)) {
+        echo $this->Form->hidden('canvasCourse', array('value' => $canvasCourseId));
+    }
+    if (!empty($canvasCourses)) {
+        echo $this->Form->input("canvasCourse", array("label"=>"Canvas Course", "multiple" => false, "default" => $canvasCourseId, "disabled"=>!empty($canvasCourseId)));
+    }
+    else {
+        echo '<div class="input select">' . $this->Form->label("Canvas Course") . '</div>';
+        echo $this->Form->select("canvasCourseInaccessible", array('0'=>'No accessible Canvas courses'), null, array("default" => '0', "disabled"=>true));
+        echo $this->Form->hidden('canvasCourse', array('value' => $canvasCourseId));
+    }
+
+    if (!empty($courseId) && !empty($canvasCourseId)) :
+
+        echo $this->Form->input("canvasGroupCategory", array("label"=>"Canvas Group set", "multiple" => false));
+
+    endif;
+
+    ?><label class="defLabel"></label><?php
+    echo $this->Form->submit(__("Export", true), array("class" => "button"));
+    echo $this->Form->end(); ?>
+
+<?php endif; ?>

--- a/app/views/groups/import.ctp
+++ b/app/views/groups/import.ctp
@@ -1,4 +1,7 @@
 <div id='groupsimport'>
+
+    <?php if ($importFrom == 'file'): ?>
+
     <h2><?php __('Instructions') ?></h2>
     <ul>
         <li><?php __('Please make sure to remove the header in CSV file.')?></li>
@@ -41,4 +44,52 @@
     echo $this->Form->submit(__('Import', true));
     echo $this->Form->end();
     ?>
+
+    <?php elseif (!empty($importSuccess)): ?>
+
+    <br><br>
+    <p><a href="/courses/home/<?php echo $courseId; ?>">&laquo; Back to course homepage</a></p>
+
+    <?php else: ?>
+
+    When you press the Import button below:
+    <ul>
+        <li><?php __('The roster for this course will be imported from Canvas.')?></li>
+        <li><?php __('All the groups from the selected group set will be imported.')?></li>
+    </ul>
+
+    <br><br>
+
+    <?php
+    echo $this->Form->create(null, array("id" => "syncCanvasForm", "class"=>"prepare", "url" => $formUrl ));
+
+    if (!empty($courseId)) {
+        echo $this->Form->hidden('Course', array('value' => $courseId));
+    }
+    echo $this->Form->input("Course", array("label"=>"iPeer Course", "multiple"=>false, "default" => $courseId, "disabled"=>!empty($courseId)));
+
+    if (!empty($canvasCourseId)) {
+        echo $this->Form->hidden('canvasCourse', array('value' => $canvasCourseId));
+    }
+    if (!empty($canvasCourses)) {
+        echo $this->Form->input("canvasCourse", array("label"=>"Canvas Course", "multiple" => false, "default" => $canvasCourseId, "disabled"=>!empty($canvasCourseId)));
+    }
+    else {
+        echo '<div class="input select">' . $this->Form->label("Canvas Course") . '</div>';
+        echo $this->Form->select("canvasCourseInaccessible", array('0'=>'No accessible Canvas courses'), null, array("default" => '0', "disabled"=>true));
+        echo $this->Form->hidden('canvasCourse', array('value' => $canvasCourseId));
+    }
+
+    if (!empty($courseId) && !empty($canvasCourseId)) :
+
+        echo $this->Form->input("canvasGroupCategory", array("label"=>"Canvas Group set", "multiple" => false));
+
+    endif;
+
+    ?><label class="defLabel"></label><?php
+    echo $this->Form->submit(__("Import", true), array("class" => "button"));
+    echo $this->Form->end();
+
+    endif; ?>
+
 </div>

--- a/app/webroot/css/ipeer.css
+++ b/app/webroot/css/ipeer.css
@@ -392,6 +392,14 @@ a#home, a#home:hover, a#home:active {
     border-bottom: solid 3px #fff;
 }
 
+.instructions {
+    border: solid 1px #ccc;
+    padding: 1em 1em 0.5em;
+    background: #fafafa;
+    border-radius: 5px;
+    box-shadow: 0 0 5px rgba(85, 85, 85, 0.28) inset;
+}
+
 /* CONTENT CONTAINER */
 .containerOuter {
     border-radius: 10px;
@@ -861,6 +869,21 @@ i {
 
 .course_actions .course_submenu:nth-child(even) {
     margin-left: 2.1%;
+}
+
+@media screen and (max-width: 865px) {
+    .course_actions .course_submenu {
+        margin-left: 0 !important;
+        width: 100%;
+    }
+}
+@media screen and (min-width: 865px) {
+    .course_submenu-TeamMaker + .course_submenu-Canvas {
+        float: right;
+        margin-top: -118px;
+        margin-right: 2px;
+        background: #fff;
+    }
 }
 
 .course_submenu h3 {


### PR DESCRIPTION
- Add new separate screens for importing and exportin Canvas groups with minimal controls
- Add new links in the Course homepage menu to the 2 new pages
- Group all Canvas functionality into 1 new submenu on Course homepage
- Comment out link to original Canvas sync screen with fine-tune functionality
- When importing, always import users from Canvas and completely replace iPeer groups with Canvas groups
- When exporting, always replace groups in Canvas with iPeer groups if they have the same name

Fixes #558 