### PR TITLE
Change Canvas API POST requests to send data in body rather than URI

### DIFF
--- a/app/controllers/components/canvas_api.php
+++ b/app/controllers/components/canvas_api.php
@@ -424,13 +424,14 @@ class CanvasApiComponent extends Object
                         ->timeoutIn($this->apiTimeout)
                         ->send();
                 } else {
-                    $response = \Httpful\Request::$method($this->getApiUrl() . $uri .
-                        ($params? '?' . $params_expanded : ''))
-                            ->expectsJson()
-                            ->addHeaders(array('Authorization' => 'Bearer ' . $accessToken))
-                            ->addHeaders($additionalHeader? $additionalHeader : array())
-                            ->timeoutIn($this->apiTimeout)
-                            ->send();
+                    $response = \Httpful\Request::$method($this->getApiUrl() . $uri)
+                        ->sendsJson()
+                        ->body(json_encode($params))
+                        ->expectsJson()
+                        ->addHeaders(array('Authorization' => 'Bearer ' . $accessToken))
+                        ->addHeaders($additionalHeader? $additionalHeader : array())
+                        ->timeoutIn($this->apiTimeout)
+                        ->send();
                 }
 
                 $callCount += 1;


### PR DESCRIPTION
We were having an issue where grades could not be sync'd for one of the courses that had a lot of groups. After investigating with live data, found out that the Canvas API server was returning a "URI Too Long" error. We seem to have implemented the request in a way where even POST data is sent as parameters in the URI. I've now changed this to instead send it in the body, like how a form is submitted. This should prevent this error in the future.