### PR TITLE
Fix Canvas grade sync and group import

### DIFF
--- a/app/controllers/components/canvas_course.php
+++ b/app/controllers/components/canvas_course.php
@@ -460,7 +460,7 @@ class CanvasCourseComponent extends Object
      * @param array   $args
      *
      * @access public
-     * @return object of type CanvasCourseAssignmentComponent
+     * @return mixed object of type CanvasCourseAssignmentComponent if successful. false otherwise
      */
     public function createAssignment($_controller, $user_id, $args, $assignment_group_name, $force_auth=false)
     {
@@ -485,16 +485,19 @@ class CanvasCourseComponent extends Object
             $defaults['assignment_group_id'] = $this->createAssignmentGroup($_controller, $user_id, $assignment_group_name, $force_auth);
         }
 
+        $the_assignment = array();
         foreach ($defaults as $key => $val) {
-            $params['assignment[' . $key . ']'] = $val;
+            $the_assignment[$key] = $val;
         }
-
         foreach ($args as $key => $val) {
-            $params['assignment[' . $key . ']'] = $val;
+            $the_assignment[$key] = $val;
         }
+        $params['assignment'] = $the_assignment;
 
         $assignment_obj = $api->postCanvasData($_controller, $force_auth, $uri, $params);
-
+        if (empty($assignment_obj)) {
+            return false;
+        }
         return new CanvasCourseAssignmentComponent($this->id, $assignment_obj);
     }
 

--- a/app/controllers/components/canvas_course_assignment.php
+++ b/app/controllers/components/canvas_course_assignment.php
@@ -114,15 +114,16 @@ class CanvasCourseAssignmentComponent extends Object
         $uri = '/courses/' . $this->course_id . '/assignments/' . $this->id . '/submissions/update_grades';
 
         $params = array();
-
+        $grade_data = array();
         foreach ($grades as $student_id => $grade) {
             $student_id += 0;
             if ($student_id) {
-                $params['grade_data[' . $student_id . '][posted_grade]'] = $grade;
+                $grade_data[$student_id]['posted_grade'] = $grade;
             }
         }
 
-        if (count($params)) {
+        if (count($grade_data)) {
+            $params['grade_data'] = $grade_data;
             return $api->postCanvasData($_controller, $force_auth, $uri, $params);
         }
 

--- a/app/controllers/components/canvas_course_grade_column.php
+++ b/app/controllers/components/canvas_course_grade_column.php
@@ -65,30 +65,4 @@ class CanvasCourseGradeColumnComponent extends Object
 
         return $grades;
     }
-
-    /**
-     * Adds a grade for the specified user in Canvas
-     *
-     * @param object  $_controller
-     * @param integer $user_id  this is the user id of the person performing this change (i.e. current user)
-     * @param integer $gradee_user_id this is the Canvas user id of the user whose grade we want updated
-     * @param string  $grade the grade for this user. Setting this to blank will delete the grade
-     * @param boolean $force_auth
-     *
-     * @access public
-     * @return object returned object
-     */
-    public function addGrade($_controller, $user_id, $gradee_user_id, $grade, $force_auth=false)
-    {
-        $api = new CanvasApiComponent($user_id);
-        $uri = '/courses/' . $this->course_id . '/custom_gradebook_columns/' . $this->id . '/data/' . $gradee_user_id;
-
-        $params = array(
-            'column_data[content]' => $grade
-        );
-
-        $retObj = $api->postCanvasData($_controller, $force_auth, $uri, $params);
-
-        return $retObj;
-    }
 }

--- a/app/controllers/groups_controller.php
+++ b/app/controllers/groups_controller.php
@@ -1131,7 +1131,7 @@ class GroupsController extends AppController
                     $insertedIds[] = $new;
                 }
 
-                foreach ($result['updated_students'] as $updated_user) {
+                foreach ($result['updated_users'] as $updated_user) {
                     $insertedIds[] = $updated_user['User']['id'];
                 }
 


### PR DESCRIPTION
With fd07a32, when calling POST methods on Canvas APIs, parameters need to be in nested
JSON format.

- change parameter format when calling postCanvasData
- remove addGrade function from CanvasCourseGradeColumnComponent. The
call to Canvas API `/v1/courses/{course_id}/custom_gradebook_columns/{id}/data/{user_id}`
should be PUT instead of POST.  But since this function
is not used anywhere, removed it for now.

Also fixed a group import issue caused by incorrect array key.

Closes #594 