### PR TITLE
FIX mixeval edit

### DIFF
--- a/app/controllers/mixevals_controller.php
+++ b/app/controllers/mixevals_controller.php
@@ -642,6 +642,13 @@ class MixevalsController extends AppController
         // Save changes if there are any
         if (!empty($this->data)) {
             $this->_dataSavePrep();
+            // This is kind of a hack. Inside _transactionSave, it will call saveAll with 'validate' option
+            // equals to 'only' to perform validation.  In turn, the cake library Model's __save function
+            // will call create() to reset the model with default values, including the 'creator_id'.
+            // Setting the created date here will let TraceableBehavior to update the creator_id properly and
+            // avoid saving the creator_id as 0.
+            $eval = $this->Mixeval->findById($id);
+            $this->data['Mixeval']['created'] = $eval['Mixeval']['created'];
             $this->_transactionalSave();
         } else {
 


### PR DESCRIPTION
When user tried to edit and save a mixed eval, the creator_id was
incorrectly updated to 0 causing the user can't access the eval.

The controller calls saveAll with 'validate' equals to 'only' to
simulate a save to perform validation. Within the cake library, it will
reset the model's default values, including the creator_id.

To avoid the creator_id reset to zero when edited, set the 'created'
date field.

Previously the 'created' field was set to current datetime whenever the
record is saved.  This logic was removed recently as it incorrectly
update the field when the record is being edited.

This fix tries to set the 'created' field to the existing value when the
record is being edited.