### PR TITLE
Better detection of https requests

### DIFF
--- a/cake/config/paths.php
+++ b/cake/config/paths.php
@@ -197,7 +197,7 @@ if (!defined('VENDORS')) {
  */
 if (!defined('FULL_BASE_URL')) {
 	$s = null;
-	if (env('HTTPS') || env('HTTP_X_FORWARDED_PROTOCOL') == 'https') {
+	if (env('HTTPS') || env('HTTP_X_FORWARDED_PROTOCOL') == 'https' || env('HTTP_X_FORWARDED_PROTO') == 'https') {
 		$s ='s';
 	}
 


### PR DESCRIPTION
The standard header to detect whether clients are using https should be `X-Forwarded-Proto`.  Adding this to CakePHP lib so that `Router:url()` can generate correct full url

ref: PRB0046794