### PR TITLE
Fixed issue with the functionality of exporting to PDF

### DIFF
--- a/app/controllers/components/export_pdf.php
+++ b/app/controllers/components/export_pdf.php
@@ -342,8 +342,10 @@ Class ExportPdfComponent extends ExportBaseNewComponent
             $numEval[$evaluateeId] = $grades[$evaluateeId];
             foreach ($evaluators as $evaluator) {
                 foreach ($evaluator as $mark) {
-                    $grades[$evaluateeId][$mark['question_number']] += $mark['grade'];
-                    $numEval[$evaluateeId][$mark['question_number']]++;
+                    if (in_array( $mark['question_number'], array_keys($grades[$evaluateeId]))) {
+                        $grades[$evaluateeId][$mark['question_number']] += $mark['grade'];
+                        $numEval[$evaluateeId][$mark['question_number']]++;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Solved the Mixed Evaluations export to pdf issue.
Test this at:  
1. http://localhost:8080/evaluations/export/course/1
2. Select "Export File Type" to pdf
3. Select "Event Name" to Project Evaluation

Note: the Project Evaluation is a Mixed Evaluations type

Closes #656 