### PR TITLE
Fixed Mixed Evaluation - Duplicate Self-Evaluations

### DIFF
--- a/app/controllers/mixevals_controller.php
+++ b/app/controllers/mixevals_controller.php
@@ -639,8 +639,36 @@ class MixevalsController extends AppController
             }
         }
 
+        /**
+         * get the event id and event index
+         * Load event index for the view to use in the Event Self-Evaluation
+         */
+        $eval = $this->Mixeval->findById($id);
+        if($this->params['action'] == 'edit') {
+            function getEventById($array, $key) {
+                foreach ($array as $value) {
+                    if($value['template_id'] == $key){
+                        return $value['id'];
+                    }
+                }
+            }
+            $event_id = getEventById($eval['Event'], $id);
+            $event_index = array_search($event_id, array_values($events));
+            $this->set('event_index', $event_index);
+        }
+
         // Save changes if there are any
         if (!empty($this->data)) {
+            /**
+             * check if the form submission includes the event data before saving
+             */
+            if(!empty($this->data['Event'])) {
+                $this->data['Event'][$event_index]['id'] = $eval['Event'][$event_index]['id'];
+                $this->data['Event'][$event_index]['created'] = $eval['Event'][$event_index]['created'];
+                $this->data['Event'][$event_index]['event_template_type_id'] = $eval['Event'][$event_index]['event_template_type_id'];
+                $this->Event->save($this->data['Event'][$event_index]);
+            }
+
             $this->_dataSavePrep();
             // This is kind of a hack. Inside _transactionSave, it will call saveAll with 'validate' option
             // equals to 'only' to perform validation.  In turn, the cake library Model's __save function

--- a/app/views/elements/evaluations/mixeval_eval_form.ctp
+++ b/app/views/elements/evaluations/mixeval_eval_form.ctp
@@ -69,7 +69,7 @@
             <?php endforeach;
         }?>
 
-        <?php if ($mixeval['Mixeval']['self_eval'] > 0 && $event['Event']['self_eval'] && $enrol > 0) { ?>
+        <?php if ($mixeval['Mixeval']['self_eval'] > 0 && $enrol > 0) { ?>
         <h1 id="self-title" class="title"><?php __("Self-Evaluation Questions")?></h1>
 
         <?php

--- a/app/views/elements/mixevals/questions_editor.ctp
+++ b/app/views/elements/mixevals/questions_editor.ctp
@@ -222,7 +222,7 @@ echo $html->div('', $reloadedQ, array('id' => 'questions', 'class' => 'questions
 
 // self evaluation questions section
 echo '<div id="self-eval-ques">';
-echo $html->tag('h3', __('Self-Evaluation Questions', true));
+echo $html->tag('h3', __('Include Additional Questions for Reflection', true));
 $addQButton = $form->button(__('Add', true),
     array('type' => 'button', 'onclick' => "insertQ(true);"));
 $selfQTypes = $qTypes;

--- a/app/views/mixevals/add.ctp
+++ b/app/views/mixevals/add.ctp
@@ -27,12 +27,40 @@ echo $html->div("help-text",
 echo $form->input('zero_mark');
 echo $html->div("help-text", 
     __('Start marks from zero for all Likert questions.', true));
+
+/**
+ * Adds evaluators to Peer Evaluation list for Self-Evaluation.
+ */
+if(isset($this->data['Mixeval']['id']) && $this->params['action'] == 'edit' && !empty($this->data['Event'])) {
+    $self_eval_checked = ($this->data['Event'][$event_index]['self_eval'] > 0) ? true : false;
+    echo $form->input('event_self_eval',
+        array(
+            'legend'  => 'Self-Evaluation',
+            'type'    => 'radio',
+            'name'    => 'data[Event]['.$event_index.'][self_eval]',
+            'value'   => $this->data['Event'][$event_index]['self_eval'],
+            'default' => $self_eval_checked,
+            'options' => array(
+                '1'   => __('Enabled', true),
+                '0'   => __('Disabled', true)
+            )
+        )
+    );
+}
+
+/**
+ * Adds a reflective questions section for evaluators.
+ */
 $check = ($this->data['Mixeval']['self_eval'] > 0) ? true : false;
-echo $form->input('self_eval', 
-    array('type' => 'checkbox', 'id' => 'self_eval', 'label' => __('Self-Evaluation', true),
-    'checked' => $check));
-echo $html->div("help-text", 
-    __('Adds a reflective questions section for evaluators.', true));
+echo $form->input('self_eval',
+    array(
+        'type'    => 'checkbox',
+        'id'      => 'self_eval',
+        'label'   => __('Additional Questions<br /> for Reflection', true),
+        'checked' => $check
+    )
+);
+echo $html->div("help-text", __('Adds a reflective questions section for evaluators.', true));
 
 // If we're editing a previously saved mixeval, will need to have an id for
 // the mixeval.


### PR DESCRIPTION
1. Copied the Self-Evaluation field from event-settings to mixeval-settings.  **Note:** The copied Self-Evaluation field will be visible Only in 'edit' mode if the mixed evaluation is attached to an event.
2. Renamed the Self-Evaluation label on the mixeval-template-page and form title to read "Include Additional Questions for Reflection".
3. Changed the behaviour of event settings for mixed evaluations to always display "Additional Questions for Reflection" questions that are part of the evaluation template regardless of event settings.