### PR TITLE
UX improvements for event template selection

### DIFF
--- a/app/controllers/events_controller.php
+++ b/app/controllers/events_controller.php
@@ -328,6 +328,24 @@ class EventsController extends AppController
             'rubrics',
             $this->Rubric->getBelongingOrPublic($this->Auth->user('id'))
         );
+        // the same lists restricted to the user's own templates, used by the
+        // "Mine only" filter on the template autocompletes
+        $this->set(
+            'mixevalsMine',
+            $this->Mixeval->getBelongingOnly($this->Auth->user('id'))
+        );
+        $this->set(
+            'simpleEvaluationsMine',
+            $this->SimpleEvaluation->getBelongingOnly($this->Auth->user('id'))
+        );
+        $this->set(
+            'surveysMine',
+            $this->Survey->getBelongingOnly($this->Auth->user('id'))
+        );
+        $this->set(
+            'rubricsMine',
+            $this->Rubric->getBelongingOnly($this->Auth->user('id'))
+        );
         $emailReminders = array('0'=> 'Disable', '1' => '1 Day', '2'=>'2 Days','3'=>'3 Days','4'=>'4 Days','5'=>'5 Days','6'=>'6 Days','7'=>'7 Days');
         $this->set('emailTemplates', $this->EmailTemplate->getPermittedEmailTemplate(User::get('id'), 'list'));
         $this->set('emailSchedules', $emailReminders);
@@ -350,6 +368,12 @@ class EventsController extends AppController
             } else if ($typeId == 4) {
                 $this->data['Event']['template_id'] =
                     $this->data['Event']['Mixeval'];
+            }
+            // no template is preselected, so the user can submit without
+            // picking one - stop here and re-render with what was entered
+            if (empty($this->data['Event']['template_id'])) {
+                $this->Session->setFlash(__('Add event failed. Please select an evaluation template.', true));
+                return;
             }
             $this->data = $this->_multiMap($this->data);
             if ($this->Event->saveAll($this->data)) {
@@ -499,66 +523,72 @@ class EventsController extends AppController
                 $this->data['Event']['template_id'] =
                     $this->data['Event']['Mixeval'];
             }
-
-            // if all groups unselected - delete groupEvents
-            if (empty($this->data['Group']['Group'])) {
-                $this->GroupEvent->deleteAll(array('GroupEvent.event_id' => $eventId));
-            }
-
-            // update submitted evaluations release status if auto-release status has been changed
-            $groupEvents = $this->GroupEvent->find('list',
-                array('conditions' => array('event_id'=>$eventId)));
-            if ($this->data['Event']['auto_release'] != $event['Event']['auto_release']) {
-                $model = null;
-                switch ($event['Event']['event_template_type_id']) {
-                case 1://simple
-                    //$model = 'EvaluationSimple';
-                    $this->EvaluationSimple->setAllEventCommentRelease($eventId, $this->Auth->user('id'), $this->data['Event']['auto_release']);
-                    $this->EvaluationSimple->setAllEventGradeRelease($eventId, $this->data['Event']['auto_release']);
-                    break;
-                case 2://rubric
-                    $this->Evaluation->changeRubricEvalCommentRelease($this->data['Event']['auto_release'], $groupEvents);
-                    $this->EvaluationRubric->setAllEventGradeRelease($eventId, $this->data['Event']['auto_release']);
-                    break;
-                case 4:
-                    $this->Evaluation->changeMixedEvalCommentRelease($this->data['Event']['auto_release'], $groupEvents);
-                    $this->EvaluationMixeval->setAllEventGradeRelease($eventId, $this->data['Event']['auto_release']);
-                    break;
-                }
-
-                if ($this->data['Event']['auto_release']) {
-                    $this->Evaluation->setGroupEventsReleaseStatus($groupEvents, 'Auto');
-                } else {
-                    $this->Evaluation->setGroupEventsReleaseStatus($groupEvents, 'None');
-                }
-            }
-
-            $penaltyData = $this->Penalty->find('all', array('conditions' => array('event_id' => $eventId), 'contain' => false));
-            $penalties = array();
-            foreach ($penaltyData as $tmp) {
-                array_splice($tmp['Penalty'], 1, -2);
-                $penalties[] = $tmp['Penalty'];
-            }
-
-            isset($this->data['Penalty']) ? $formPenalty = $this->data['Penalty'] : $formPenalty = array();
-            // check differences (table vs form data), delete what's missing in form data from db
-            foreach ($penalties as $pTmp) {
-                if (!in_array($pTmp, $formPenalty)) {
-                    $this->Penalty->delete($pTmp['id']);
-                }
-            }
-            $this->data = $this->_multiMap($this->data);
-            if ($this->Event->saveAll($this->data)) {
-                $this->Session->setFlash("Edit event successful!", 'good');
-                if ($this->checkIfChanged($event, $this->data, $orig_email_frequency, $emailTemp)) {
-                    // only delete emails that haven't been sent
-                    $this->EmailSchedule->deleteAll(array('event_id' => $eventId, 'sent' => 0), false);
-                    $this->setSchedule($eventId, $this->data);
-                }
-                $this->redirect('index/'.$event['Event']['course_id']);
-                return;
+            // no template is preselected, so the user can submit without
+            // picking one - stop before anything is deleted or saved
+            if (empty($this->data['Event']['template_id'])) {
+                $this->Session->setFlash(__('Edit event failed. Please select an evaluation template.', true));
             } else {
-                $this->Session->setFlash("Edit event failed.");
+
+                // if all groups unselected - delete groupEvents
+                if (empty($this->data['Group']['Group'])) {
+                    $this->GroupEvent->deleteAll(array('GroupEvent.event_id' => $eventId));
+                }
+
+                // update submitted evaluations release status if auto-release status has been changed
+                $groupEvents = $this->GroupEvent->find('list',
+                    array('conditions' => array('event_id'=>$eventId)));
+                if ($this->data['Event']['auto_release'] != $event['Event']['auto_release']) {
+                    $model = null;
+                    switch ($event['Event']['event_template_type_id']) {
+                    case 1://simple
+                        //$model = 'EvaluationSimple';
+                        $this->EvaluationSimple->setAllEventCommentRelease($eventId, $this->Auth->user('id'), $this->data['Event']['auto_release']);
+                        $this->EvaluationSimple->setAllEventGradeRelease($eventId, $this->data['Event']['auto_release']);
+                        break;
+                    case 2://rubric
+                        $this->Evaluation->changeRubricEvalCommentRelease($this->data['Event']['auto_release'], $groupEvents);
+                        $this->EvaluationRubric->setAllEventGradeRelease($eventId, $this->data['Event']['auto_release']);
+                        break;
+                    case 4:
+                        $this->Evaluation->changeMixedEvalCommentRelease($this->data['Event']['auto_release'], $groupEvents);
+                        $this->EvaluationMixeval->setAllEventGradeRelease($eventId, $this->data['Event']['auto_release']);
+                        break;
+                    }
+
+                    if ($this->data['Event']['auto_release']) {
+                        $this->Evaluation->setGroupEventsReleaseStatus($groupEvents, 'Auto');
+                    } else {
+                        $this->Evaluation->setGroupEventsReleaseStatus($groupEvents, 'None');
+                    }
+                }
+
+                $penaltyData = $this->Penalty->find('all', array('conditions' => array('event_id' => $eventId), 'contain' => false));
+                $penalties = array();
+                foreach ($penaltyData as $tmp) {
+                    array_splice($tmp['Penalty'], 1, -2);
+                    $penalties[] = $tmp['Penalty'];
+                }
+
+                isset($this->data['Penalty']) ? $formPenalty = $this->data['Penalty'] : $formPenalty = array();
+                // check differences (table vs form data), delete what's missing in form data from db
+                foreach ($penalties as $pTmp) {
+                    if (!in_array($pTmp, $formPenalty)) {
+                        $this->Penalty->delete($pTmp['id']);
+                    }
+                }
+                $this->data = $this->_multiMap($this->data);
+                if ($this->Event->saveAll($this->data)) {
+                    $this->Session->setFlash("Edit event successful!", 'good');
+                    if ($this->checkIfChanged($event, $this->data, $orig_email_frequency, $emailTemp)) {
+                        // only delete emails that haven't been sent
+                        $this->EmailSchedule->deleteAll(array('event_id' => $eventId, 'sent' => 0), false);
+                        $this->setSchedule($eventId, $this->data);
+                    }
+                    $this->redirect('index/'.$event['Event']['course_id']);
+                    return;
+                } else {
+                    $this->Session->setFlash("Edit event failed.");
+                }
             }
         } else if (!empty($this->data)) {
             $this->Session->setFlash("Edit event failed because the form hasn't finished loading yet.");
@@ -605,6 +635,26 @@ class EventsController extends AppController
         $this->set(
             'rubrics',
             $this->Rubric->getBelongingOrPublic($this->Auth->user('id'), $rubricSelected)
+        );
+        // the same lists restricted to the user's own templates, used by the
+        // "Mine only" filter on the template autocompletes. The already
+        // attached template is included so it stays selectable when filtering,
+        // even if it is somebody else's public template.
+        $this->set(
+            'mixevalsMine',
+            $this->Mixeval->getBelongingOnly($this->Auth->user('id'), $mixevalSelected)
+        );
+        $this->set(
+            'simpleEvaluationsMine',
+            $this->SimpleEvaluation->getBelongingOnly($this->Auth->user('id'), $simpleSelected)
+        );
+        $this->set(
+            'surveysMine',
+            $this->Survey->getBelongingOnly($this->Auth->user('id'), $surveySelected)
+        );
+        $this->set(
+            'rubricsMine',
+            $this->Rubric->getBelongingOnly($this->Auth->user('id'), $rubricSelected)
         );
         $this->set(
             'eventTemplateTypes',

--- a/app/models/evaluation_base.php
+++ b/app/models/evaluation_base.php
@@ -136,6 +136,40 @@ class EvaluationBase extends AppModel
 
 
     /**
+     * getBelongingOnly
+     * Returns only the evaluations made by this user - public ones made by
+     * other users are excluded. Optionally include an additional evaluation by
+     * id, so a template already attached to an event stays selectable even if
+     * it belongs to somebody else.
+     *
+     * @param mixed $user_id
+     * @param mixed $include_id
+     *
+     * @access public
+     * @return array
+     */
+    function getBelongingOnly($user_id, $include_id=NULL)
+    {
+        if (!is_numeric($user_id)) {
+            return false;
+        }
+
+        if (!is_null($include_id) && !is_numeric($include_id)) {
+            return false;
+        }
+
+        $conditions = array('creator_id' => $user_id);
+        if (!is_null($include_id)) {
+            $conditions = array('OR' => array(
+                'creator_id' => $user_id,
+                'id' => $include_id,
+            ));
+        }
+        return $this->find('list', array('conditions' => $conditions, 'fields' => array('name'), 'order' => 'name ASC'));
+    }
+
+
+    /**
      * getEventCount
      *
      * @param mixed $evaluation_id

--- a/app/models/mixeval.php
+++ b/app/models/mixeval.php
@@ -204,6 +204,42 @@ class Mixeval extends AppModel
     }
 
     /**
+     * getBelongingOnly
+     * Returns only the mixed evaluations made by this user - public ones made
+     * by other users are excluded. Optionally include an additional evaluation
+     * by id, so a template already attached to an event stays selectable even
+     * if it belongs to somebody else.
+     *
+     * Note duplicate in evaluation_base, for the same reason
+     * getBelongingOrPublic above is duplicated.
+     *
+     * @param mixed $user_id
+     * @param mixed $include_id
+     *
+     * @access public
+     * @return array
+     */
+    function getBelongingOnly($user_id, $include_id=NULL)
+    {
+        if (!is_numeric($user_id)) {
+            return false;
+        }
+
+        if (!is_null($include_id) && !is_numeric($include_id)) {
+            return false;
+        }
+
+        $conditions = array('creator_id' => $user_id);
+        if (!is_null($include_id)) {
+            $conditions = array('OR' => array(
+                'creator_id' => $user_id,
+                'id' => $include_id,
+            ));
+        }
+        return $this->find('list', array('conditions' => $conditions, 'fields' => array('name'), 'order' => 'name'));
+    }
+
+    /**
      * formatPenaltyArray return the array that student has penalty. key will
      * be the user id and value will be the penalty. The student without
      * penalty will be value 0.

--- a/app/tests/cases/controllers/events_controller.test.php
+++ b/app/tests/cases/controllers/events_controller.test.php
@@ -143,6 +143,10 @@ class EventsControllerTest extends ExtendedAuthTestCase {
         $this->assertEqual($result['rubrics'][1], 'Term Report Evaluation');
         $this->assertEqual($result['simpleEvaluations'][1], 'Module 1 Project Evaluation');
         $this->assertEqual($result['mixevals'][1], 'Default Mix Evaluation');
+        // root created the sample templates, so the "Mine only" lists match
+        $this->assertEqual($result['rubricsMine'][1], 'Term Report Evaluation');
+        $this->assertEqual($result['simpleEvaluationsMine'][1], 'Module 1 Project Evaluation');
+        $this->assertEqual($result['mixevalsMine'][1], 'Default Mix Evaluation');
         // evauation types
         $this->assertEqual(count($result['eventTemplateTypes']), 4);
         // course list
@@ -158,6 +162,99 @@ class EventsControllerTest extends ExtendedAuthTestCase {
             1 => 'Reapers',
             2 => 'Lazy Engineers',
         ));
+    }
+
+    function testAddTemplateListsExcludeOthersFromMine() {
+        // instructor1 did not create the sample templates - they only show up
+        // in the full lists, because they are public
+        $this->login = array(
+            'User' => array(
+                'username' => 'instructor1',
+                'password' => md5('ipeeripeer')
+            )
+        );
+        $result = $this->testAction('/events/add/1', array('return' => 'vars'));
+
+        $this->assertEqual($result['rubrics'][1], 'Term Report Evaluation');
+        $this->assertFalse(isset($result['rubricsMine'][1]));
+        $this->assertFalse(isset($result['simpleEvaluationsMine'][1]));
+        $this->assertFalse(isset($result['mixevalsMine'][1]));
+    }
+
+    function testAddWithoutTemplate() {
+        $data = array(
+            'Event' => array(
+                'title' => 'no template evaluation',
+                'description' => 'no template selected',
+                'event_template_type_id' => 1,
+                'SimpleEvaluation' => '',
+                'self_eval' => 0,
+                'com_req' => 0,
+                'due_date' => '2012-11-28 00:00:01',
+                'release_date_begin' => '2012-11-20 00:00:01',
+                'release_date_end' => '2012-11-29 00:00:01',
+                'result_release_date_begin' => '2012-11-30 00:00:01',
+                'result_release_date_end' => '2022-12-12 00:00:01',
+                'email_schedule' => 0,
+                'EmailTemplate' => 2,
+            ),
+            'Group' => array(
+                'Group' => array(1,2)
+            ),
+        );
+        $this->testAction(
+            '/events/add/1',
+            array('fixturize' => true, 'data' => $data, 'method' => 'post')
+        );
+
+        $message = $this->controller->Session->read('Message.flash');
+        $this->assertEqual($message['message'], 'Add event failed. Please select an evaluation template.');
+
+        $model = ClassRegistry::init('Event');
+        $event = $model->find('first', array('conditions' => array('title' => 'no template evaluation'), 'contain' => false));
+        $this->assertFalse($event);
+    }
+
+    function testEditWithoutTemplate() {
+        $data = array(
+            'formLoaded' => true,
+            'Event' => array(
+                'id' => 8,
+                'title' => 'simple evaluation 4a',
+                'description' => 'no template selected',
+                'event_template_type_id' => 1,
+                'SimpleEvaluation' => '',
+                'self_eval' => 0,
+                'com_req' => 0,
+                'enable_details' => 0,
+                'auto_release' => 0,
+                'due_date' => '2012-11-28 00:00:01',
+                'release_date_begin' => '2012-11-20 00:00:01',
+                'release_date_end' => '2012-11-29 00:00:01',
+                'result_release_date_begin' => '2012-11-30 00:00:01',
+                'result_release_date_end' => '2022-12-12 00:00:01',
+                'email_schedule' => 0,
+                'EmailTemplate' => 2,
+            ),
+            // no groups submitted - the guard has to stop before the
+            // GroupEvent rows are deleted
+            'Group' => array(
+                'Group' => array()
+            ),
+        );
+        $this->testAction(
+            '/events/edit/8',
+            array('fixturize' => true, 'data' => $data, 'method' => 'post')
+        );
+
+        $message = $this->controller->Session->read('Message.flash');
+        $this->assertEqual($message['message'], 'Edit event failed. Please select an evaluation template.');
+
+        $model = ClassRegistry::init('Event');
+        $event = $model->find('first', array('conditions' => array('id' => 8), 'contain' => array('GroupEvent')));
+        // nothing saved and nothing deleted
+        $this->assertEqual($event['Event']['title'], 'simple evaluation 4');
+        $this->assertEqual(count($event['GroupEvent']), 1);
     }
 
     function testAddWithData() {

--- a/app/views/events/add.ctp
+++ b/app/views/events/add.ctp
@@ -1,21 +1,28 @@
 <div id='Events'>
 <?php
 $html->script("jquery-ui-timepicker-addon", array("inline"=>false));
+$html->script("template_autocomplete", array("inline"=>false));
 
 echo $this->Form->create('Event', array('action' => "add/$course_id"));
 echo $this->Form->input('course_id', array('default' => $course_id));
 echo $this->Form->input('title', array('label' => 'Event Title'));
 echo "<div id='titleWarning' class='red'></div>";
 echo $this->Form->input('description', array('type' => 'textarea'));
+echo "<div class='templateBox'>";
 echo $this->Form->input('event_template_type_id');
+// 'empty' means no template is preselected - the user has to pick one. The
+// selects are hidden by initTemplateAutocomplete() below and replaced with a
+// search box, but they remain the fields that are submitted.
+$templateEmpty = __('-- Select a template --', true);
 echo $this->Form->input('SimpleEvaluation',
-    array('div' => array('id' => 'SimpleEvalDiv'), 'label' => $html->link('Preview', '', array('id' => 'prevS', 'target' => '_blank'))));
+    array('div' => array('id' => 'SimpleEvalDiv'), 'empty' => $templateEmpty, 'label' => $html->link('Preview', '', array('id' => 'prevS', 'class' => 'templatePreviewLink', 'target' => '_blank'))));
 echo $this->Form->input('Rubric',
-    array('div' => array('id' => 'RubricDiv'), 'label' => $html->link('Preview', '', array('id' => 'prevR', 'target' => '_blank'))));
+    array('div' => array('id' => 'RubricDiv'), 'empty' => $templateEmpty, 'label' => $html->link('Preview', '', array('id' => 'prevR', 'class' => 'templatePreviewLink', 'target' => '_blank'))));
 echo $this->Form->input('Survey',
-    array('div' => array('id' => 'SurveyDiv'), 'label' => $html->link('Preview', '', array('id' => 'prevV', 'target' => '_blank'))));
+    array('div' => array('id' => 'SurveyDiv'), 'empty' => $templateEmpty, 'label' => $html->link('Preview', '', array('id' => 'prevV', 'class' => 'templatePreviewLink', 'target' => '_blank'))));
 echo $this->Form->input('Mixeval',
-    array('div' => array('id' => 'MixevalDiv'), 'label' => $html->link('Preview', '', array('id' => 'prevM', 'target' => '_blank'))));
+    array('div' => array('id' => 'MixevalDiv'), 'empty' => $templateEmpty, 'label' => $html->link('Preview', '', array('id' => 'prevM', 'class' => 'templatePreviewLink', 'target' => '_blank'))));
+echo "</div>";
 echo $this->Form->input(
     'self_eval',
     array(
@@ -176,6 +183,13 @@ jQuery("#EventSimpleEvaluation").change(updatePreview);
 jQuery("#EventRubric").change(updatePreview);
 jQuery("#EventSurvey").change(updatePreview);
 jQuery("#EventMixeval").change(updatePreview);
+// turn the four template selects into searchable inputs with a "Mine only"
+// filter. Done after the change handlers above so picking an item updates the
+// Preview links.
+initTemplateAutocomplete("#EventSimpleEvaluation", <?php echo json_encode(array_keys((array) $simpleEvaluationsMine)); ?>);
+initTemplateAutocomplete("#EventRubric", <?php echo json_encode(array_keys((array) $rubricsMine)); ?>);
+initTemplateAutocomplete("#EventSurvey", <?php echo json_encode(array_keys((array) $surveysMine)); ?>);
+initTemplateAutocomplete("#EventMixeval", <?php echo json_encode(array_keys((array) $mixevalsMine)); ?>);
 jQuery("#EventEmailSchedule").change(toggleEmailTemplate);
 jQuery("#EventEmailTemplate").change(updateEmailPreview);
 jQuery("input:radio[name=data['Event']['self_eval']]").change(toggleSelfEval);

--- a/app/views/events/edit.ctp
+++ b/app/views/events/edit.ctp
@@ -23,6 +23,7 @@ function checkGroups() {
 
 <?php
 $html->script("jquery-ui-timepicker-addon", array("inline"=>false));
+$html->script("template_autocomplete", array("inline"=>false));
 echo $this->Form->create('Event', array('action' => "edit", "onsubmit" => "return checkGroups()"));
 echo '<input type="hidden" name="required" id="required" value="eventId" />';
 echo $this->Form->input('id');
@@ -54,40 +55,51 @@ if ($lockEvaluationType === true) {
     echo '<div style="display:none">'; // hides the following fields
 }
 
+echo "<div class='templateBox'>";
 echo $this->Form->input('event_template_type_id');
 
+// 'empty' covers the case where the event's template has been deleted - the
+// selected value below still wins whenever the template still exists. The
+// selects are hidden by initTemplateAutocomplete() below and replaced with a
+// search box, but they remain the fields that are submitted.
+$templateEmpty = __('-- Select a template --', true);
 echo $this->Form->input('SimpleEvaluation',
     array(
         'div' => array('id' => 'SimpleEvalDiv'),
+        'empty' => $templateEmpty,
         'label' => $html->link(
-            'Preview', '', array('id' => 'prevS', 'target' => '_blank')),
+            'Preview', '', array('id' => 'prevS', 'class' => 'templatePreviewLink', 'target' => '_blank')),
         'selected' => $simpleSelected
     )
 );
 echo $this->Form->input('Rubric',
     array(
         'div' => array('id' => 'RubricDiv'),
+        'empty' => $templateEmpty,
         'label' => $html->link(
-            'Preview', '', array('id' => 'prevR', 'target' => '_blank')),
+            'Preview', '', array('id' => 'prevR', 'class' => 'templatePreviewLink', 'target' => '_blank')),
         'selected'=> $rubricSelected
     )
 );
 echo $this->Form->input('Survey',
     array(
         'div' => array('id' => 'SurveyDiv'),
+        'empty' => $templateEmpty,
         'label' => $html->link(
-            'Preview', '', array('id' => 'prevV', 'target' => '_blank')),
+            'Preview', '', array('id' => 'prevV', 'class' => 'templatePreviewLink', 'target' => '_blank')),
         'selected' => $surveySelected
     )
 );
 echo $this->Form->input('Mixeval',
     array(
         'div' => array('id' => 'MixevalDiv'),
+        'empty' => $templateEmpty,
         'label' => $html->link(
-            'Preview', '', array('id' => 'prevM', 'target' => '_blank')),
+            'Preview', '', array('id' => 'prevM', 'class' => 'templatePreviewLink', 'target' => '_blank')),
         'selected' => $mixevalSelected
     )
 );
+echo "</div>";
 
 if ($lockEvaluationType === true) {
     echo '</div>';
@@ -269,6 +281,13 @@ jQuery("#EventSimpleEvaluation").change(updatePreview);
 jQuery("#EventRubric").change(updatePreview);
 jQuery("#EventSurvey").change(updatePreview);
 jQuery("#EventMixeval").change(updatePreview);
+// turn the four template selects into searchable inputs with a "Mine only"
+// filter. Done after the change handlers above so picking an item updates the
+// Preview links.
+initTemplateAutocomplete("#EventSimpleEvaluation", <?php echo json_encode(array_keys((array) $simpleEvaluationsMine)); ?>);
+initTemplateAutocomplete("#EventRubric", <?php echo json_encode(array_keys((array) $rubricsMine)); ?>);
+initTemplateAutocomplete("#EventSurvey", <?php echo json_encode(array_keys((array) $surveysMine)); ?>);
+initTemplateAutocomplete("#EventMixeval", <?php echo json_encode(array_keys((array) $mixevalsMine)); ?>);
 jQuery("#EventEmailSchedule").change(toggleEmailTemplate);
 jQuery("#EventEmailTemplate").change(updateEmailPreview);
 jQuery("input:radio[name=data['Event']['self_eval']]").change(toggleSelfEval);

--- a/app/webroot/css/ipeer.css
+++ b/app/webroot/css/ipeer.css
@@ -1189,6 +1189,26 @@ i {
     margin-bottom: 0.5em;
 }
 
+/* search box that replaces the evaluation template selects */
+#Events .templateAutocomplete {
+    width: 20em;
+}
+
+#Events .templateFilter {
+    margin-left: 0.5em;
+    font-size: 0.9em;
+    color: gray;
+    white-space: nowrap;
+}
+
+/* the label is inside div.select, so undo the 18em form label width */
+#Events .select label.templateMineOnlyLabel {
+    display: inline;
+    width: auto;
+    margin-left: 0.25em;
+    font-weight: normal;
+}
+
 #Events .text label, #Events .password label,
 #Events .textarea label, #Events .select label,
 #Events .datetime label, #Events .radio legend,
@@ -2516,4 +2536,70 @@ pre code {
     margin: 0 0.2em;
     border-radius: 3px;
     font-size: 0.95em;
+}
+
+/* Events - evaluation type and template selection box
+ * These rules come after the earlier #Events template rules on purpose, so the
+ * "Mine only" label overrides land last without editing anything above.
+ * */
+#Events .templateBox {
+    clear: both;
+    overflow: hidden; /* contain the floated labels */
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background-color: #fafafa;
+    /* no left padding, so labels stay aligned with the rest of the form */
+    padding: 0.75em 1em 0.75em 0;
+    margin: 0.5em 0 1em 0;
+}
+
+/* the "Mine only" label sits inside div.select, where the shared form styling
+ * floats labels into their own 18em column - undo that so the label stays
+ * beside its checkbox */
+#Events .templateBox .select label.templateMineOnlyLabel {
+    float: none;
+    clear: none;
+    display: inline;
+    width: auto;
+    min-width: 0;
+    margin: 0 0 0 0.25em;
+    padding: 0;
+    text-align: left;
+    font-weight: normal;
+    vertical-align: middle;
+    font-size: 0.9em;
+}
+
+/* the input and the filter line share this box, which sits wherever the form
+ * label ends */
+#Events .templateBox .templateField {
+    display: inline-block;
+    vertical-align: top;
+}
+
+/* own line below the search box, indented by the input's own margin so the
+ * checkbox lines up with the left edge of the box above it */
+#Events .templateBox .templateFilter {
+    display: block;
+    margin-left: 0.35em;
+    white-space: nowrap;
+}
+
+#Events .templateBox .templateMineOnly {
+    margin: 0;
+    vertical-align: middle;
+}
+
+/* the autocomplete menu is appended to the body, so it cannot be scoped to
+ * #Events - the "no matching templates" row is a message, not a choice */
+.ui-autocomplete li.templateNoResults a {
+    color: gray;
+    font-style: italic;
+    cursor: default;
+}
+
+.ui-autocomplete li.templateNoResults a.ui-state-hover,
+.ui-autocomplete li.templateNoResults a.ui-state-focus {
+    background: none;
+    border-color: transparent;
 }

--- a/app/webroot/js/template_autocomplete.js
+++ b/app/webroot/js/template_autocomplete.js
@@ -1,0 +1,173 @@
+/**
+ * Turns an evaluation template <select> into a searchable jQuery UI
+ * autocomplete text box with a "Mine only" filter.
+ *
+ * The original <select> stays in the DOM (hidden) and remains the field that
+ * is submitted, so the form still posts the template id and existing code that
+ * reads or watches the select by id - updatePreview(), the Preview links -
+ * keeps working. The text box is only a search interface over the options.
+ *
+ * @param selectSelector jQuery selector for the template select
+ * @param mineIds        array of template ids created by the current user
+ */
+function initTemplateAutocomplete(selectSelector, mineIds) {
+    var select = jQuery(selectSelector);
+    if (!select.length) {
+        return;
+    }
+
+    var mine = {};
+    for (var i = 0; i < mineIds.length; i++) {
+        mine[String(mineIds[i])] = true;
+    }
+
+    // the full list comes from the select's own options, so there is no second
+    // copy of the template names to keep in sync
+    var all = [];
+    select.find('option').each(function () {
+        var option = jQuery(this);
+        if (option.val() === '') {
+            return; // the "-- Select a template --" placeholder
+        }
+        all.push({label: option.text(), value: option.val()});
+    });
+
+    var input = jQuery('<input />').attr({
+        'type': 'text',
+        'class': 'templateAutocomplete',
+        'autocomplete': 'off',
+        'placeholder': 'Click or type to search templates'
+    });
+    var mineOnly = jQuery('<input />').attr({
+        'type': 'checkbox',
+        'class': 'templateMineOnly',
+        'id': select.attr('id') + 'MineOnly'
+    });
+    var mineOnlyLabel = jQuery('<label />')
+        .attr({'class': 'templateMineOnlyLabel', 'for': mineOnly.attr('id')})
+        .text('Only show templates I created');
+
+    // input and filter share one inline-block, so the filter line starts at
+    // the input's left edge no matter how wide the form label is
+    select.hide();
+    jQuery('<span />').addClass('templateField')
+        .append(input)
+        .append(jQuery('<span />').addClass('templateFilter')
+            .append(mineOnly).append(mineOnlyLabel))
+        .insertAfter(select);
+
+    // the Preview link is this field's label - it points nowhere until a
+    // template is picked, so hide it while the selection is empty. Only the
+    // link is hidden, its label keeps its place in the layout.
+    var previewLink = select.parent().find('a.templatePreviewLink');
+    function updatePreviewVisibility() {
+        var value = select.val();
+        previewLink.toggle(value !== '' && value !== null);
+    }
+    select.change(updatePreviewVisibility);
+
+    function currentSource() {
+        if (!mineOnly.is(':checked')) {
+            return all;
+        }
+        return jQuery.grep(all, function (template) {
+            return mine[template.value] === true;
+        });
+    }
+
+    function labelFor(value) {
+        for (var i = 0; i < all.length; i++) {
+            if (all[i].value === String(value)) {
+                return all[i].label;
+            }
+        }
+        return '';
+    }
+
+    function setTemplate(value) {
+        select.val(value);
+        input.val(labelFor(value));
+        select.change(); // keeps the Preview links up to date
+    }
+
+    function matches(term) {
+        if (!term) {
+            return currentSource();
+        }
+        var matcher = new RegExp(jQuery.ui.autocomplete.escapeRegex(term), 'i');
+        return jQuery.grep(currentSource(), function (template) {
+            return matcher.test(template.label);
+        });
+    }
+
+    input.autocomplete({
+        minLength: 0,
+        source: function (request, response) {
+            var found = matches(request.term);
+            if (!found.length) {
+                // the menu has no built-in empty state - show one, and mark it
+                // so it cannot be picked
+                found = [{label: 'No matching templates', value: '', noResults: true}];
+            }
+            response(found);
+        },
+        select: function (event, ui) {
+            if (ui.item.noResults) {
+                return false;
+            }
+            setTemplate(ui.item.value);
+            return false; // we set the label ourselves, item.value is the id
+        },
+        focus: function () {
+            return false; // arrowing the menu must not put the id in the box
+        }
+    });
+
+    // grey out the "no matches" row so it does not look selectable
+    input.data('autocomplete')._renderItem = function (ul, item) {
+        return jQuery('<li />')
+            .addClass(item.noResults ? 'templateNoResults' : '')
+            .data('item.autocomplete', item)
+            .append(jQuery('<a />').text(item.label))
+            .appendTo(ul);
+    };
+
+    // clicking the box offers the whole (filtered) list, like a dropdown
+    input.click(function () {
+        input.autocomplete('search', input.val() === '' ? '' : input.val());
+    });
+
+    // Enter means "I am done typing", not "submit the form". If exactly one
+    // template matches what was typed, take it.
+    input.keydown(function (event) {
+        if (event.keyCode !== jQuery.ui.keyCode.ENTER) {
+            return;
+        }
+        event.preventDefault();
+        if (input.data('autocomplete').menu.active) {
+            return; // the menu handled it, an item was highlighted
+        }
+        var found = matches(input.val());
+        if (found.length === 1) {
+            setTemplate(found[0].value);
+        }
+        input.autocomplete('close');
+    });
+
+    // the select is the source of truth - discard anything typed that was not
+    // picked from the menu
+    input.blur(function () {
+        input.val(labelFor(select.val()));
+    });
+
+    mineOnly.change(function () {
+        var selected = select.val();
+        if (mineOnly.is(':checked') && selected && mine[String(selected)] !== true) {
+            setTemplate(''); // current pick is not the user's own - clear it
+        }
+        input.autocomplete('close');
+    });
+
+    input.val(labelFor(select.val()));
+    updatePreviewVisibility();
+}


### PR DESCRIPTION
Typeahead UI added, plus a "Only show templates I created" checkbox.

<img width="508" height="194" alt="image" src="https://github.com/user-attachments/assets/d53d45c1-3718-4464-8784-22c92b514f0c" />
